### PR TITLE
feat(ablation): feature ablation framework with 6-measure signal tiers

### DIFF
--- a/ablation_reports/experiments/20260401_201228_v3.0-all-modes/experiment.json
+++ b/ablation_reports/experiments/20260401_201228_v3.0-all-modes/experiment.json
@@ -1,0 +1,1915 @@
+{
+  "meta": {
+    "timestamp": "2026-04-01T20:12:28.439682",
+    "tag": "v3.0-all-modes",
+    "mode_filter": null,
+    "split_filter": null,
+    "n_pairs": 6293,
+    "n_missing": 0,
+    "n_features": 34,
+    "feature_keys": [
+      "jaccard",
+      "dice",
+      "cosine",
+      "rouge",
+      "rouge3",
+      "mixedbread-ai/mxbai-embed-large-v1",
+      "Qwen/Qwen3-Embedding-0.6B",
+      "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1",
+      "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1",
+      "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B",
+      "SOFT_COL_Qwen/Qwen3-Embedding-0.6B",
+      "PREC_mixedbread-ai/mxbai-embed-large-v1",
+      "REC_mixedbread-ai/mxbai-embed-large-v1",
+      "PREC_Qwen/Qwen3-Embedding-0.6B",
+      "REC_Qwen/Qwen3-Embedding-0.6B",
+      "entailment",
+      "neutral",
+      "contradiction",
+      "entity_person",
+      "entity_organization",
+      "entity_location",
+      "entity_product",
+      "entity_event",
+      "entity_law",
+      "entity_language",
+      "entity_date",
+      "entity_time",
+      "entity_duration",
+      "entity_number",
+      "entity_quantity",
+      "entity_percentage",
+      "entity_money",
+      "lcs_token",
+      "lcs_char"
+    ],
+    "framework_version": "1.0",
+    "bonferroni_alpha": 0.05,
+    "bonferroni_threshold": 0.0014705882352941176,
+    "redundancy_threshold": 0.85
+  },
+  "global_stats": {
+    "pca": {
+      "explained_variance": [
+        0.3399045169353485,
+        0.06805835664272308,
+        0.058259181678295135,
+        0.04487378150224686,
+        0.04399317502975464,
+        0.0407927930355072,
+        0.03540518879890442,
+        0.030856408178806305,
+        0.03034738264977932,
+        0.029179789125919342
+      ],
+      "cumulative_variance": [
+        0.3399045169353485,
+        0.4079628586769104,
+        0.46622204780578613,
+        0.5110958218574524,
+        0.555088996887207,
+        0.5958818197250366,
+        0.6312869787216187,
+        0.6621434092521667,
+        0.692490816116333,
+        0.7216706275939941
+      ],
+      "top3_loadings_per_pc": {
+        "PC01": [
+          {
+            "feature": "dice",
+            "loading": 0.2787187695503235
+          },
+          {
+            "feature": "jaccard",
+            "loading": 0.271376371383667
+          },
+          {
+            "feature": "Qwen/Qwen3-Embedding-0.6B",
+            "loading": 0.26914215087890625
+          }
+        ],
+        "PC02": [
+          {
+            "feature": "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B",
+            "loading": 0.4800822138786316
+          },
+          {
+            "feature": "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1",
+            "loading": 0.4800822138786316
+          },
+          {
+            "feature": "SOFT_COL_Qwen/Qwen3-Embedding-0.6B",
+            "loading": 0.3225838840007782
+          }
+        ],
+        "PC03": [
+          {
+            "feature": "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1",
+            "loading": 0.47307100892066956
+          },
+          {
+            "feature": "SOFT_COL_Qwen/Qwen3-Embedding-0.6B",
+            "loading": 0.47307088971138
+          },
+          {
+            "feature": "contradiction",
+            "loading": -0.2673976421356201
+          }
+        ],
+        "PC04": [
+          {
+            "feature": "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B",
+            "loading": 0.43827900290489197
+          },
+          {
+            "feature": "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1",
+            "loading": 0.43827900290489197
+          },
+          {
+            "feature": "contradiction",
+            "loading": -0.33267009258270264
+          }
+        ],
+        "PC05": [
+          {
+            "feature": "entity_date",
+            "loading": 0.43297767639160156
+          },
+          {
+            "feature": "entity_language",
+            "loading": 0.3746359050273895
+          },
+          {
+            "feature": "entity_location",
+            "loading": 0.31342560052871704
+          }
+        ],
+        "PC06": [
+          {
+            "feature": "neutral",
+            "loading": 0.6263129711151123
+          },
+          {
+            "feature": "entailment",
+            "loading": -0.5473708510398865
+          },
+          {
+            "feature": "entity_percentage",
+            "loading": -0.2647821307182312
+          }
+        ],
+        "PC07": [
+          {
+            "feature": "contradiction",
+            "loading": 0.5167952179908752
+          },
+          {
+            "feature": "entity_quantity",
+            "loading": -0.37917807698249817
+          },
+          {
+            "feature": "neutral",
+            "loading": -0.32169145345687866
+          }
+        ],
+        "PC08": [
+          {
+            "feature": "entity_law",
+            "loading": 0.7233046889305115
+          },
+          {
+            "feature": "entity_duration",
+            "loading": -0.3937811851501465
+          },
+          {
+            "feature": "entity_event",
+            "loading": 0.306816965341568
+          }
+        ],
+        "PC09": [
+          {
+            "feature": "entity_percentage",
+            "loading": 0.5656974911689758
+          },
+          {
+            "feature": "entailment",
+            "loading": -0.352927565574646
+          },
+          {
+            "feature": "entity_money",
+            "loading": 0.314014732837677
+          }
+        ],
+        "PC10": [
+          {
+            "feature": "entity_product",
+            "loading": 0.8253991603851318
+          },
+          {
+            "feature": "entity_money",
+            "loading": -0.3442108929157257
+          },
+          {
+            "feature": "entity_number",
+            "loading": 0.25699612498283386
+          }
+        ]
+      }
+    },
+    "kmeans": {
+      "ari": 0.061697126816673546,
+      "cluster_stats": [
+        {
+          "cluster": 0,
+          "n": 3106,
+          "label1_rate": 0.3737926593689633
+        },
+        {
+          "cluster": 1,
+          "n": 3187,
+          "label1_rate": 0.6225290241606527
+        }
+      ],
+      "top10_discriminative": [
+        {
+          "feature": "dice",
+          "centroid_distance": 1.6152231693267822
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "centroid_distance": 1.5425288677215576
+        },
+        {
+          "feature": "rouge",
+          "centroid_distance": 1.5401604175567627
+        },
+        {
+          "feature": "jaccard",
+          "centroid_distance": 1.5219173431396484
+        },
+        {
+          "feature": "lcs_token",
+          "centroid_distance": 1.5129709243774414
+        },
+        {
+          "feature": "lcs_char",
+          "centroid_distance": 1.5076059103012085
+        },
+        {
+          "feature": "mixedbread-ai/mxbai-embed-large-v1",
+          "centroid_distance": 1.4949522018432617
+        },
+        {
+          "feature": "cosine",
+          "centroid_distance": 1.4757604598999023
+        },
+        {
+          "feature": "REC_Qwen/Qwen3-Embedding-0.6B",
+          "centroid_distance": 1.4723851680755615
+        },
+        {
+          "feature": "PREC_Qwen/Qwen3-Embedding-0.6B",
+          "centroid_distance": 1.463768482208252
+        }
+      ]
+    }
+  },
+  "features": {
+    "jaccard": {
+      "pearson_r": 0.1309262422197161,
+      "pearson_p": 1.8274606394673868e-25,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.1556835350923171,
+      "spearman_p": 1.9485753101274573e-35,
+      "cohens_d": 0.2640848457813263,
+      "mutual_info_bits": 0.10817366214492527,
+      "max_cross_r": 0.9827503856750022,
+      "top3_correlated_peers": [
+        {
+          "feature": "dice",
+          "cross_r": 0.9827503856750022
+        },
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.92617419877511
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.9211525786862073
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 10,
+        "model-vs-model": 14,
+        "reference-vs-generated": 14
+      },
+      "tier": "MODERATE",
+      "verdict": "REVIEW",
+      "reason": "Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1309 (p=1.83e-25, Bonferroni:OK), Spearman r=+0.1557, Cohen's d=0.2641, MI=0.1082 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9828 with 'dice' (cross_r=+0.9828)"
+    },
+    "dice": {
+      "pearson_r": 0.14600747657264004,
+      "pearson_p": 2.5002016001605683e-31,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.1528782632184151,
+      "spearman_p": 3.2271515799161246e-34,
+      "cohens_d": 0.29513323307037354,
+      "mutual_info_bits": 0.11167463527397944,
+      "max_cross_r": 0.9827503856750023,
+      "top3_correlated_peers": [
+        {
+          "feature": "jaccard",
+          "cross_r": 0.9827503856750023
+        },
+        {
+          "feature": "cosine",
+          "cross_r": 0.9380130611138936
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.9342059669063361
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 11,
+        "model-vs-model": 9,
+        "reference-vs-generated": 10
+      },
+      "tier": "MODERATE",
+      "verdict": "REVIEW",
+      "reason": "Moderate signal but highly correlated with 'jaccard'. Ablation test recommended before dropping. Pearson r=+0.1460 (p=2.50e-31, Bonferroni:OK), Spearman r=+0.1529, Cohen's d=0.2951, MI=0.1117 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9828 with 'jaccard' (cross_r=+0.9828)"
+    },
+    "cosine": {
+      "pearson_r": 0.13877348231092182,
+      "pearson_p": 1.9599369746351405e-28,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.14093953427674788,
+      "spearman_p": 2.763382984669427e-29,
+      "cohens_d": 0.2802191376686096,
+      "mutual_info_bits": 0.23408416147920705,
+      "max_cross_r": 0.9380130611138935,
+      "top3_correlated_peers": [
+        {
+          "feature": "dice",
+          "cross_r": 0.9380130611138935
+        },
+        {
+          "feature": "jaccard",
+          "cross_r": 0.9160349813952904
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.8640373286095655
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 12,
+        "model-vs-model": 11,
+        "reference-vs-generated": 11
+      },
+      "tier": "MODERATE",
+      "verdict": "REVIEW",
+      "reason": "Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1388 (p=1.96e-28, Bonferroni:OK), Spearman r=+0.1409, Cohen's d=0.2802, MI=0.2341 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9380 with 'dice' (cross_r=+0.9380)"
+    },
+    "rouge": {
+      "pearson_r": 0.13038747740313256,
+      "pearson_p": 2.8792015269329403e-25,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.13196957417875205,
+      "spearman_p": 7.536617973902215e-26,
+      "cohens_d": 0.26297906041145325,
+      "mutual_info_bits": 0.11406153556300509,
+      "max_cross_r": 0.9342059669063358,
+      "top3_correlated_peers": [
+        {
+          "feature": "dice",
+          "cross_r": 0.9342059669063358
+        },
+        {
+          "feature": "jaccard",
+          "cross_r": 0.9211525786862074
+        },
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.8930258488931422
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 14,
+        "model-vs-model": 13,
+        "reference-vs-generated": 9
+      },
+      "tier": "MODERATE",
+      "verdict": "REVIEW",
+      "reason": "Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1304 (p=2.88e-25, Bonferroni:OK), Spearman r=+0.1320, Cohen's d=0.2630, MI=0.1141 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9342 with 'dice' (cross_r=+0.9342)"
+    },
+    "rouge3": {
+      "pearson_r": 0.11750749352058369,
+      "pearson_p": 8.580368792462687e-21,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.14768956759598023,
+      "spearman_p": 5.050355453073942e-32,
+      "cohens_d": 0.23660968244075775,
+      "mutual_info_bits": 0.08837023356721796,
+      "max_cross_r": 0.8361412225194508,
+      "top3_correlated_peers": [
+        {
+          "feature": "jaccard",
+          "cross_r": 0.8361412225194508
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.8255729909498234
+        },
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.8164914128413054
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 16,
+        "model-vs-model": 15,
+        "reference-vs-generated": 12
+      },
+      "tier": "WEAK",
+      "verdict": "KEEP",
+      "reason": "Small but validated independent signal. Pearson r=+0.1175 (p=8.58e-21, Bonferroni:OK), Spearman r=+0.1477, Cohen's d=0.2366, MI=0.0884 bits, mode_consistency=1.00"
+    },
+    "mixedbread-ai/mxbai-embed-large-v1": {
+      "pearson_r": 0.27294904783543095,
+      "pearson_p": 6.322973277684404e-108,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.27775423213448336,
+      "spearman_p": 7.617922032769281e-112,
+      "cohens_d": 0.5673748850822449,
+      "mutual_info_bits": 0.26875356638858533,
+      "max_cross_r": 0.9670148999635299,
+      "top3_correlated_peers": [
+        {
+          "feature": "REC_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9670148999635299
+        },
+        {
+          "feature": "PREC_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9661168070278844
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9116280486495051
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 5,
+        "model-vs-model": 5,
+        "reference-vs-generated": 5
+      },
+      "tier": "STRONG",
+      "verdict": "KEEP",
+      "reason": "Strong multi-measure signal. Core feature. Pearson r=+0.2729 (p=6.32e-108, Bonferroni:OK), Spearman r=+0.2778, Cohen's d=0.5674, MI=0.2688 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9670 with 'REC_mixedbread-ai/mxbai-embed-large-v1' (cross_r=+0.9670)"
+    },
+    "Qwen/Qwen3-Embedding-0.6B": {
+      "pearson_r": 0.23555754226552242,
+      "pearson_p": 4.419358226055681e-80,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.2340368537215709,
+      "spearman_p": 4.792885555117529e-79,
+      "cohens_d": 0.48469415307044983,
+      "mutual_info_bits": 0.259519929202333,
+      "max_cross_r": 0.9663507456370768,
+      "top3_correlated_peers": [
+        {
+          "feature": "REC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9663507456370768
+        },
+        {
+          "feature": "PREC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.963408408265765
+        },
+        {
+          "feature": "mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9116280486495051
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 8,
+        "model-vs-model": 8,
+        "reference-vs-generated": 8
+      },
+      "tier": "MODERATE",
+      "verdict": "REVIEW",
+      "reason": "Moderate signal but highly correlated with 'REC_Qwen/Qwen3-Embedding-0.6B'. Ablation test recommended before dropping. Pearson r=+0.2356 (p=4.42e-80, Bonferroni:OK), Spearman r=+0.2340, Cohen's d=0.4847, MI=0.2595 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9664 with 'REC_Qwen/Qwen3-Embedding-0.6B' (cross_r=+0.9664)"
+    },
+    "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1": {
+      "pearson_r": -0.009039588099925383,
+      "pearson_p": 0.4733935100891483,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": -0.0069462165317741,
+      "spearman_p": 0.5816819061544036,
+      "cohens_d": -0.018077081069350243,
+      "mutual_info_bits": 0.01575199100195348,
+      "max_cross_r": 0.9999999999417646,
+      "top3_correlated_peers": [
+        {
+          "feature": "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9999999999417646
+        },
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.32956457411632073
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.3085587520019345
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 24,
+        "model-vs-model": 28,
+        "reference-vs-generated": 23
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=-0.0090 (p=4.73e-01, Bonferroni:FAIL), Spearman r=-0.0069, Cohen's d=-0.0181, MI=0.0158 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_ROW_Qwen/Qwen3-Embedding-0.6B' (cross_r=+1.0000)"
+    },
+    "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1": {
+      "pearson_r": 0.0031814158146051008,
+      "pearson_p": 0.800788143123381,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.005215341787907633,
+      "spearman_p": 0.6791337399736946,
+      "cohens_d": 0.006362114101648331,
+      "mutual_info_bits": 0.022746661327048542,
+      "max_cross_r": 0.9999999999208539,
+      "top3_correlated_peers": [
+        {
+          "feature": "SOFT_COL_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9999999999208539
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.32975757407625333
+        },
+        {
+          "feature": "mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.3240968921100846
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 26,
+        "model-vs-model": 34,
+        "reference-vs-generated": 26
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0032 (p=8.01e-01, Bonferroni:FAIL), Spearman r=+0.0052, Cohen's d=0.0064, MI=0.0227 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_COL_Qwen/Qwen3-Embedding-0.6B' (cross_r=+1.0000)"
+    },
+    "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B": {
+      "pearson_r": -0.00903957321209289,
+      "pearson_p": 0.4733942387370388,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": -0.007463766976747431,
+      "spearman_p": 0.5538642821025024,
+      "cohens_d": -0.018076729029417038,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.9999999999417646,
+      "top3_correlated_peers": [
+        {
+          "feature": "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9999999999417646
+        },
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.3295645427635417
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.3085587875818847
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 23,
+        "model-vs-model": 27,
+        "reference-vs-generated": 24
+      },
+      "tier": "NOISE",
+      "verdict": "DROP",
+      "reason": "No statistically significant or practically meaningful signal on any measure. Pearson r=-0.0090 (p=4.73e-01, Bonferroni:FAIL), Spearman r=-0.0075, Cohen's d=-0.0181, MI=0.0000 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1' (cross_r=+1.0000)"
+    },
+    "SOFT_COL_Qwen/Qwen3-Embedding-0.6B": {
+      "pearson_r": 0.003181386941792217,
+      "pearson_p": 0.8007899130269632,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.005091746357936746,
+      "spearman_p": 0.686328446765055,
+      "cohens_d": 0.006361454725265503,
+      "mutual_info_bits": 0.005307479205498927,
+      "max_cross_r": 0.9999999999208539,
+      "top3_correlated_peers": [
+        {
+          "feature": "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9999999999208539
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.3297575346064523
+        },
+        {
+          "feature": "mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.3240968190388935
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 25,
+        "model-vs-model": 33,
+        "reference-vs-generated": 25
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0032 (p=8.01e-01, Bonferroni:FAIL), Spearman r=+0.0051, Cohen's d=0.0064, MI=0.0053 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_COL_mixedbread-ai/mxbai-embed-large-v1' (cross_r=+1.0000)"
+    },
+    "PREC_mixedbread-ai/mxbai-embed-large-v1": {
+      "pearson_r": 0.2927616401516958,
+      "pearson_p": 1.3362013138461978e-124,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.29925226913218766,
+      "spearman_p": 2.3067912726324857e-130,
+      "cohens_d": 0.6122850775718689,
+      "mutual_info_bits": 0.27563088439814987,
+      "max_cross_r": 0.9661168070278844,
+      "top3_correlated_peers": [
+        {
+          "feature": "mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9661168070278844
+        },
+        {
+          "feature": "REC_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9518373399750404
+        },
+        {
+          "feature": "PREC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9021938610630401
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 3,
+        "model-vs-model": 3,
+        "reference-vs-generated": 3
+      },
+      "tier": "STRONG",
+      "verdict": "KEEP",
+      "reason": "Strong multi-measure signal. Core feature. Pearson r=+0.2928 (p=1.34e-124, Bonferroni:OK), Spearman r=+0.2993, Cohen's d=0.6123, MI=0.2756 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9661 with 'mixedbread-ai/mxbai-embed-large-v1' (cross_r=+0.9661)"
+    },
+    "REC_mixedbread-ai/mxbai-embed-large-v1": {
+      "pearson_r": 0.2813350121708456,
+      "pearson_p": 8.12096058229282e-115,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.2872883788232535,
+      "spearman_p": 7.401973486486359e-120,
+      "cohens_d": 0.5862873792648315,
+      "mutual_info_bits": 0.260497528205819,
+      "max_cross_r": 0.9670148999635299,
+      "top3_correlated_peers": [
+        {
+          "feature": "mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9670148999635299
+        },
+        {
+          "feature": "PREC_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9518373399750403
+        },
+        {
+          "feature": "REC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9055183626539316
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 4,
+        "model-vs-model": 4,
+        "reference-vs-generated": 4
+      },
+      "tier": "STRONG",
+      "verdict": "KEEP",
+      "reason": "Strong multi-measure signal. Core feature. Pearson r=+0.2813 (p=8.12e-115, Bonferroni:OK), Spearman r=+0.2873, Cohen's d=0.5863, MI=0.2605 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9670 with 'mixedbread-ai/mxbai-embed-large-v1' (cross_r=+0.9670)"
+    },
+    "PREC_Qwen/Qwen3-Embedding-0.6B": {
+      "pearson_r": 0.2536514337478712,
+      "pearson_p": 5.630978119829714e-93,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.25289643523705707,
+      "spearman_p": 2.0423399793527514e-92,
+      "cohens_d": 0.5243935585021973,
+      "mutual_info_bits": 0.2664600036772569,
+      "max_cross_r": 0.9634084082657651,
+      "top3_correlated_peers": [
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9634084082657651
+        },
+        {
+          "feature": "REC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.950726016868074
+        },
+        {
+          "feature": "PREC_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9021938610630401
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 7,
+        "model-vs-model": 6,
+        "reference-vs-generated": 6
+      },
+      "tier": "STRONG",
+      "verdict": "KEEP",
+      "reason": "Strong multi-measure signal. Core feature. Pearson r=+0.2537 (p=5.63e-93, Bonferroni:OK), Spearman r=+0.2529, Cohen's d=0.5244, MI=0.2665 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9634 with 'Qwen/Qwen3-Embedding-0.6B' (cross_r=+0.9634)"
+    },
+    "REC_Qwen/Qwen3-Embedding-0.6B": {
+      "pearson_r": 0.24402330883958961,
+      "pearson_p": 5.5633881782535284e-86,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.24068167144078115,
+      "spearman_p": 1.2647703323353593e-83,
+      "cohens_d": 0.5032016634941101,
+      "mutual_info_bits": 0.2512168523936625,
+      "max_cross_r": 0.9663507456370768,
+      "top3_correlated_peers": [
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9663507456370768
+        },
+        {
+          "feature": "PREC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.9507260168680739
+        },
+        {
+          "feature": "REC_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.9055183626539317
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 9,
+        "model-vs-model": 7,
+        "reference-vs-generated": 7
+      },
+      "tier": "MODERATE",
+      "verdict": "REVIEW",
+      "reason": "Moderate signal but highly correlated with 'Qwen/Qwen3-Embedding-0.6B'. Ablation test recommended before dropping. Pearson r=+0.2440 (p=5.56e-86, Bonferroni:OK), Spearman r=+0.2407, Cohen's d=0.5032, MI=0.2512 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9664 with 'Qwen/Qwen3-Embedding-0.6B' (cross_r=+0.9664)"
+    },
+    "entailment": {
+      "pearson_r": 0.4903856042657443,
+      "pearson_p": 0.0,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.4877588615176292,
+      "spearman_p": 0.0,
+      "cohens_d": 1.1251261234283447,
+      "mutual_info_bits": 0.37529404922852283,
+      "max_cross_r": 0.6379649327344002,
+      "top3_correlated_peers": [
+        {
+          "feature": "neutral",
+          "cross_r": -0.6379649327344002
+        },
+        {
+          "feature": "contradiction",
+          "cross_r": -0.48008587322529594
+        },
+        {
+          "feature": "mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.4613436852232539
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 1,
+        "model-vs-model": 1,
+        "reference-vs-generated": 2
+      },
+      "tier": "STRONG",
+      "verdict": "KEEP",
+      "reason": "Strong multi-measure signal. Core feature. Pearson r=+0.4904 (p=0.00e+00, Bonferroni:OK), Spearman r=+0.4878, Cohen's d=1.1251, MI=0.3753 bits, mode_consistency=1.00"
+    },
+    "neutral": {
+      "pearson_r": -0.09586289664160892,
+      "pearson_p": 2.5230783355274355e-14,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": -0.0814037389335073,
+      "spearman_p": 9.99130080692562e-11,
+      "cohens_d": -0.19258332252502441,
+      "mutual_info_bits": 0.29067870769025334,
+      "max_cross_r": 0.6379649327344002,
+      "top3_correlated_peers": [
+        {
+          "feature": "entailment",
+          "cross_r": -0.6379649327344002
+        },
+        {
+          "feature": "jaccard",
+          "cross_r": -0.38972752527167703
+        },
+        {
+          "feature": "dice",
+          "cross_r": -0.38635760201956754
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 6,
+        "model-vs-model": 16,
+        "reference-vs-generated": 17
+      },
+      "tier": "WEAK",
+      "verdict": "KEEP",
+      "reason": "Small but validated independent signal. Pearson r=-0.0959 (p=2.52e-14, Bonferroni:OK), Spearman r=-0.0814, Cohen's d=-0.1926, MI=0.2907 bits, mode_consistency=1.00"
+    },
+    "contradiction": {
+      "pearson_r": -0.4826071348482649,
+      "pearson_p": 0.0,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": -0.46699061402198955,
+      "spearman_p": 0.0,
+      "cohens_d": -1.102074384689331,
+      "mutual_info_bits": 0.38144564315664253,
+      "max_cross_r": 0.480085873225296,
+      "top3_correlated_peers": [
+        {
+          "feature": "entailment",
+          "cross_r": -0.480085873225296
+        },
+        {
+          "feature": "neutral",
+          "cross_r": -0.36923998480529463
+        },
+        {
+          "feature": "REC_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": -0.26114755243785126
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 2,
+        "model-vs-model": 2,
+        "reference-vs-generated": 1
+      },
+      "tier": "STRONG",
+      "verdict": "KEEP",
+      "reason": "Strong multi-measure signal. Core feature. Pearson r=-0.4826 (p=0.00e+00, Bonferroni:OK), Spearman r=-0.4670, Cohen's d=-1.1021, MI=0.3814 bits, mode_consistency=1.00"
+    },
+    "entity_person": {
+      "pearson_r": 0.00862397057224382,
+      "pearson_p": 0.4939733522755349,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.011816671232879087,
+      "spearman_p": 0.3486328067850115,
+      "cohens_d": 0.017246130853891373,
+      "mutual_info_bits": 0.010049630185085392,
+      "max_cross_r": 0.3961112378868137,
+      "top3_correlated_peers": [
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.3961112378868137
+        },
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.38040285091757386
+        },
+        {
+          "feature": "dice",
+          "cross_r": 0.3752910903135114
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 20,
+        "model-vs-model": 20,
+        "reference-vs-generated": 29
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0086 (p=4.94e-01, Bonferroni:FAIL), Spearman r=+0.0118, Cohen's d=0.0172, MI=0.0100 bits, mode_consistency=0.00"
+    },
+    "entity_organization": {
+      "pearson_r": -0.0038082163888776585,
+      "pearson_p": 0.7626208734286277,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": -0.0020094438946088532,
+      "spearman_p": 0.8733738073516882,
+      "cohens_d": -0.007615452632308006,
+      "mutual_info_bits": 0.0031371879942374927,
+      "max_cross_r": 0.2736908372346129,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.2736908372346129
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.2210519466556395
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.21858233226173562
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 19,
+        "model-vs-model": 31,
+        "reference-vs-generated": 27
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=-0.0038 (p=7.63e-01, Bonferroni:FAIL), Spearman r=-0.0020, Cohen's d=-0.0076, MI=0.0031 bits, mode_consistency=0.00"
+    },
+    "entity_location": {
+      "pearson_r": 0.026273733404307793,
+      "pearson_p": 0.03714199915808626,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.029185416185092662,
+      "spearman_p": 0.020598351127292164,
+      "cohens_d": 0.05255778133869171,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.29401947447249316,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.29401947447249316
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.2395340126922158
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.2331973296622527
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 29,
+        "model-vs-model": 19,
+        "reference-vs-generated": 33
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0263 (p=3.71e-02, Bonferroni:FAIL), Spearman r=+0.0292, Cohen's d=0.0526, MI=0.0000 bits, mode_consistency=0.00"
+    },
+    "entity_product": {
+      "pearson_r": 0.04189829880542399,
+      "pearson_p": 0.0008856902452139403,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.039753125708704755,
+      "spearman_p": 0.001609534347479654,
+      "cohens_d": 0.08385951817035675,
+      "mutual_info_bits": 0.003917905480254674,
+      "max_cross_r": 0.14438039290145027,
+      "top3_correlated_peers": [
+        {
+          "feature": "PREC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.14438039290145027
+        },
+        {
+          "feature": "REC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.13835816046734012
+        },
+        {
+          "feature": "Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.13453701905197393
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 21,
+        "model-vs-model": 18,
+        "reference-vs-generated": 30
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0419 (p=8.86e-04, Bonferroni:OK), Spearman r=+0.0398, Cohen's d=0.0839, MI=0.0039 bits, mode_consistency=0.00"
+    },
+    "entity_event": {
+      "pearson_r": 0.008087220147620937,
+      "pearson_p": 0.521243651380229,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.0029259353048558933,
+      "spearman_p": 0.8164881149665603,
+      "cohens_d": 0.01617276854813099,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.17817834091219015,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.17817834091219015
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.16662313684926147
+        },
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.15813418177508953
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 31,
+        "model-vs-model": 29,
+        "reference-vs-generated": 22
+      },
+      "tier": "NOISE",
+      "verdict": "DROP",
+      "reason": "No statistically significant or practically meaningful signal on any measure. Pearson r=+0.0081 (p=5.21e-01, Bonferroni:FAIL), Spearman r=+0.0029, Cohen's d=0.0162, MI=0.0000 bits, mode_consistency=0.00"
+    },
+    "entity_law": {
+      "pearson_r": 0.03400951864121979,
+      "pearson_p": 0.006972260200707518,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.026217032086105114,
+      "spearman_p": 0.037553028930669995,
+      "cohens_d": 0.06805112957954407,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.06645828910442056,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.06645828910442056
+        },
+        {
+          "feature": "PREC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.06598538396577407
+        },
+        {
+          "feature": "jaccard",
+          "cross_r": 0.0635274452930831
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 18,
+        "model-vs-model": 25,
+        "reference-vs-generated": 18
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0340 (p=6.97e-03, Bonferroni:FAIL), Spearman r=+0.0262, Cohen's d=0.0681, MI=0.0000 bits, mode_consistency=0.00"
+    },
+    "entity_language": {
+      "pearson_r": 0.02117322884019981,
+      "pearson_p": 0.09305588053429416,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.017734183585430083,
+      "spearman_p": 0.1595293876444278,
+      "cohens_d": 0.0423504076898098,
+      "mutual_info_bits": 0.007513171491586027,
+      "max_cross_r": 0.1928067153108231,
+      "top3_correlated_peers": [
+        {
+          "feature": "entity_date",
+          "cross_r": 0.1928067153108231
+        },
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.17500383513755338
+        },
+        {
+          "feature": "REC_Qwen/Qwen3-Embedding-0.6B",
+          "cross_r": 0.1418272969100333
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 33,
+        "model-vs-model": 22,
+        "reference-vs-generated": 19
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0212 (p=9.31e-02, Bonferroni:FAIL), Spearman r=+0.0177, Cohen's d=0.0424, MI=0.0075 bits, mode_consistency=0.00"
+    },
+    "entity_date": {
+      "pearson_r": -0.013676969625993332,
+      "pearson_p": 0.27800681356992046,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": -0.01794038973834059,
+      "spearman_p": 0.1547318735647321,
+      "cohens_d": -0.027351731434464455,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.262287525142137,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.262287525142137
+        },
+        {
+          "feature": "entity_time",
+          "cross_r": 0.2123761588140121
+        },
+        {
+          "feature": "entity_language",
+          "cross_r": 0.19280671531082308
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 22,
+        "model-vs-model": 32,
+        "reference-vs-generated": 20
+      },
+      "tier": "NOISE",
+      "verdict": "DROP",
+      "reason": "No statistically significant or practically meaningful signal on any measure. Pearson r=-0.0137 (p=2.78e-01, Bonferroni:FAIL), Spearman r=-0.0179, Cohen's d=-0.0274, MI=0.0000 bits, mode_consistency=0.00"
+    },
+    "entity_time": {
+      "pearson_r": 0.029595607300842635,
+      "pearson_p": 0.018883595788104036,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.023907704149195057,
+      "spearman_p": 0.057899911449678036,
+      "cohens_d": 0.05920889228582382,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.2904519377880038,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.2904519377880038
+        },
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.2327848230854023
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.21508616880257225
+        }
+      ],
+      "mode_consistency": 0.3333333333333333,
+      "mode_ranks": {
+        "context-vs-generated": 17,
+        "model-vs-model": 26,
+        "reference-vs-generated": 31
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0296 (p=1.89e-02, Bonferroni:FAIL), Spearman r=+0.0239, Cohen's d=0.0592, MI=0.0000 bits, mode_consistency=0.33"
+    },
+    "entity_duration": {
+      "pearson_r": 0.024982015928837045,
+      "pearson_p": 0.04751286042483442,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.02269653277497765,
+      "spearman_p": 0.0718046702849119,
+      "cohens_d": 0.04997329041361809,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.11151891658110073,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.11151891658110073
+        },
+        {
+          "feature": "entity_time",
+          "cross_r": 0.10906989483657212
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.09094317448364228
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 28,
+        "model-vs-model": 23,
+        "reference-vs-generated": 21
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0250 (p=4.75e-02, Bonferroni:FAIL), Spearman r=+0.0227, Cohen's d=0.0500, MI=0.0000 bits, mode_consistency=0.00"
+    },
+    "entity_number": {
+      "pearson_r": 0.0172908382731227,
+      "pearson_p": 0.17022378117678968,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.012377159070305063,
+      "spearman_p": 0.32624610629109996,
+      "cohens_d": 0.03458208963274956,
+      "mutual_info_bits": 0.012261865600516265,
+      "max_cross_r": 0.1315850252717108,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.1315850252717108
+        },
+        {
+          "feature": "entity_location",
+          "cross_r": 0.11492521040676867
+        },
+        {
+          "feature": "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1",
+          "cross_r": 0.10863152322114375
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 34,
+        "model-vs-model": 24,
+        "reference-vs-generated": 28
+      },
+      "tier": "MARGINAL",
+      "verdict": "REVIEW",
+      "reason": "Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0173 (p=1.70e-01, Bonferroni:FAIL), Spearman r=+0.0124, Cohen's d=0.0346, MI=0.0123 bits, mode_consistency=0.00"
+    },
+    "entity_quantity": {
+      "pearson_r": 0.018088281517833676,
+      "pearson_p": 0.15135911503495122,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.02713878270410079,
+      "spearman_p": 0.031330793391998284,
+      "cohens_d": 0.03617744892835617,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.13424413532723276,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.13424413532723276
+        },
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.11736963632265725
+        },
+        {
+          "feature": "entity_number",
+          "cross_r": 0.1056780976150265
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 32,
+        "model-vs-model": 21,
+        "reference-vs-generated": 34
+      },
+      "tier": "NOISE",
+      "verdict": "DROP",
+      "reason": "No statistically significant or practically meaningful signal on any measure. Pearson r=+0.0181 (p=1.51e-01, Bonferroni:FAIL), Spearman r=+0.0271, Cohen's d=0.0362, MI=0.0000 bits, mode_consistency=0.00"
+    },
+    "entity_percentage": {
+      "pearson_r": 0.06582860468952896,
+      "pearson_p": 1.725507841717283e-07,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.0792882363561273,
+      "spearman_p": 3.005798355084401e-10,
+      "cohens_d": 0.1319354921579361,
+      "mutual_info_bits": 0.005314692515658402,
+      "max_cross_r": 0.09567738015421198,
+      "top3_correlated_peers": [
+        {
+          "feature": "entity_quantity",
+          "cross_r": 0.09567738015421198
+        },
+        {
+          "feature": "neutral",
+          "cross_r": -0.07504620190768294
+        },
+        {
+          "feature": "entailment",
+          "cross_r": 0.06908250547685484
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 15,
+        "model-vs-model": 17,
+        "reference-vs-generated": 16
+      },
+      "tier": "WEAK",
+      "verdict": "KEEP",
+      "reason": "Small but validated independent signal. Pearson r=+0.0658 (p=1.73e-07, Bonferroni:OK), Spearman r=+0.0793, Cohen's d=0.1319, MI=0.0053 bits, mode_consistency=1.00"
+    },
+    "entity_money": {
+      "pearson_r": 0.011544829268864085,
+      "pearson_p": 0.359833826270366,
+      "pearson_significant_bonferroni": false,
+      "spearman_r": 0.015211300424677901,
+      "spearman_p": 0.22761755828720348,
+      "cohens_d": 0.023087333887815475,
+      "mutual_info_bits": 0.0,
+      "max_cross_r": 0.09472863474774022,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.09472863474774022
+        },
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.08279076500684401
+        },
+        {
+          "feature": "rouge",
+          "cross_r": 0.07597543438741029
+        }
+      ],
+      "mode_consistency": 0.0,
+      "mode_ranks": {
+        "context-vs-generated": 30,
+        "model-vs-model": 30,
+        "reference-vs-generated": 32
+      },
+      "tier": "NOISE",
+      "verdict": "DROP",
+      "reason": "No statistically significant or practically meaningful signal on any measure. Pearson r=+0.0115 (p=3.60e-01, Bonferroni:FAIL), Spearman r=+0.0152, Cohen's d=0.0231, MI=0.0000 bits, mode_consistency=0.00"
+    },
+    "lcs_token": {
+      "pearson_r": 0.128146490011056,
+      "pearson_p": 1.868870244832754e-24,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.12442482580440925,
+      "spearman_p": 3.88186047296698e-23,
+      "cohens_d": 0.25837722420692444,
+      "mutual_info_bits": 0.08710865969952163,
+      "max_cross_r": 0.9263023128358381,
+      "top3_correlated_peers": [
+        {
+          "feature": "dice",
+          "cross_r": 0.9263023128358381
+        },
+        {
+          "feature": "jaccard",
+          "cross_r": 0.9261741987751099
+        },
+        {
+          "feature": "lcs_char",
+          "cross_r": 0.9212548091274648
+        }
+      ],
+      "mode_consistency": 1.0,
+      "mode_ranks": {
+        "context-vs-generated": 13,
+        "model-vs-model": 10,
+        "reference-vs-generated": 13
+      },
+      "tier": "MODERATE",
+      "verdict": "REVIEW",
+      "reason": "Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1281 (p=1.87e-24, Bonferroni:OK), Spearman r=+0.1244, Cohen's d=0.2584, MI=0.0871 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9263 with 'dice' (cross_r=+0.9263)"
+    },
+    "lcs_char": {
+      "pearson_r": 0.09183376576469517,
+      "pearson_p": 2.898958856463736e-13,
+      "pearson_significant_bonferroni": true,
+      "spearman_r": 0.09049903038914615,
+      "spearman_p": 6.362385026465179e-13,
+      "cohens_d": 0.1844116449356079,
+      "mutual_info_bits": 0.25044046108790896,
+      "max_cross_r": 0.9212548091274647,
+      "top3_correlated_peers": [
+        {
+          "feature": "lcs_token",
+          "cross_r": 0.9212548091274647
+        },
+        {
+          "feature": "dice",
+          "cross_r": 0.8510427443200704
+        },
+        {
+          "feature": "jaccard",
+          "cross_r": 0.8422681824285296
+        }
+      ],
+      "mode_consistency": 0.6666666666666666,
+      "mode_ranks": {
+        "context-vs-generated": 27,
+        "model-vs-model": 12,
+        "reference-vs-generated": 15
+      },
+      "tier": "WEAK",
+      "verdict": "REVIEW",
+      "reason": "Small signal but near-duplicate (max_cross_r>=0.85) of higher-tier feature 'lcs_token'. Ablation test before dropping. Pearson r=+0.0918 (p=2.90e-13, Bonferroni:OK), Spearman r=+0.0905, Cohen's d=0.1844, MI=0.2504 bits, mode_consistency=0.67. REDUNDANT: max_cross_r=0.9213 with 'lcs_token' (cross_r=+0.9213)"
+    }
+  },
+  "tier_summary": {
+    "STRONG": [
+      "mixedbread-ai/mxbai-embed-large-v1",
+      "PREC_mixedbread-ai/mxbai-embed-large-v1",
+      "REC_mixedbread-ai/mxbai-embed-large-v1",
+      "PREC_Qwen/Qwen3-Embedding-0.6B",
+      "entailment",
+      "contradiction"
+    ],
+    "MODERATE": [
+      "jaccard",
+      "dice",
+      "cosine",
+      "rouge",
+      "Qwen/Qwen3-Embedding-0.6B",
+      "REC_Qwen/Qwen3-Embedding-0.6B",
+      "lcs_token"
+    ],
+    "WEAK": [
+      "rouge3",
+      "neutral",
+      "entity_percentage",
+      "lcs_char"
+    ],
+    "MARGINAL": [
+      "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1",
+      "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1",
+      "SOFT_COL_Qwen/Qwen3-Embedding-0.6B",
+      "entity_person",
+      "entity_organization",
+      "entity_location",
+      "entity_product",
+      "entity_law",
+      "entity_language",
+      "entity_time",
+      "entity_duration",
+      "entity_number"
+    ],
+    "NOISE": [
+      "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B",
+      "entity_event",
+      "entity_date",
+      "entity_quantity",
+      "entity_money"
+    ]
+  },
+  "verdict_summary": {
+    "KEEP": [
+      "rouge3",
+      "mixedbread-ai/mxbai-embed-large-v1",
+      "PREC_mixedbread-ai/mxbai-embed-large-v1",
+      "REC_mixedbread-ai/mxbai-embed-large-v1",
+      "PREC_Qwen/Qwen3-Embedding-0.6B",
+      "entailment",
+      "neutral",
+      "contradiction",
+      "entity_percentage"
+    ],
+    "REVIEW": [
+      "jaccard",
+      "dice",
+      "cosine",
+      "rouge",
+      "Qwen/Qwen3-Embedding-0.6B",
+      "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1",
+      "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1",
+      "SOFT_COL_Qwen/Qwen3-Embedding-0.6B",
+      "REC_Qwen/Qwen3-Embedding-0.6B",
+      "entity_person",
+      "entity_organization",
+      "entity_location",
+      "entity_product",
+      "entity_law",
+      "entity_language",
+      "entity_time",
+      "entity_duration",
+      "entity_number",
+      "lcs_token",
+      "lcs_char"
+    ],
+    "DROP": [
+      "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B",
+      "entity_event",
+      "entity_date",
+      "entity_quantity",
+      "entity_money"
+    ]
+  },
+  "per_mode_correlations": {
+    "context-vs-generated": {
+      "n": 2231,
+      "features": {
+        "jaccard": {
+          "pearson_r": 0.1076119253057155,
+          "pearson_p": 3.4904345192364896e-07
+        },
+        "dice": {
+          "pearson_r": 0.09145032006328176,
+          "pearson_p": 1.5172978898794016e-05
+        },
+        "cosine": {
+          "pearson_r": 0.07138381908715585,
+          "pearson_p": 0.0007405201174266954
+        },
+        "rouge": {
+          "pearson_r": 0.054624029772159646,
+          "pearson_p": 0.009863940639113174
+        },
+        "rouge3": {
+          "pearson_r": 0.05313021185919846,
+          "pearson_p": 0.012076869520409376
+        },
+        "mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.1421392209319075,
+          "pearson_p": 1.538368633171924e-11
+        },
+        "Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.12054628324957992,
+          "pearson_p": 1.1200727512794229e-08
+        },
+        "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": -0.01963244315264066,
+          "pearson_p": 0.35398993039845517
+        },
+        "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.017037092135395802,
+          "pearson_p": 0.42120743296497815
+        },
+        "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": -0.019632596139922163,
+          "pearson_p": 0.35398617916525205
+        },
+        "SOFT_COL_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.017037138563537113,
+          "pearson_p": 0.4212061672387532
+        },
+        "PREC_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.1541138253095635,
+          "pearson_p": 2.497972102713873e-13
+        },
+        "REC_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.14272055997493385,
+          "pearson_p": 1.2692440383589241e-11
+        },
+        "PREC_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.13092720061071217,
+          "pearson_p": 5.38627886736972e-10
+        },
+        "REC_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.12035641195093831,
+          "pearson_p": 1.181297101168295e-08
+        },
+        "entailment": {
+          "pearson_r": 0.5183094178822119,
+          "pearson_p": 1.2130158633295174e-153
+        },
+        "neutral": {
+          "pearson_r": -0.134411264824118,
+          "pearson_p": 1.8404656198416832e-10
+        },
+        "contradiction": {
+          "pearson_r": -0.44241002458847073,
+          "pearson_p": 1.4243829694128303e-107
+        },
+        "entity_person": {
+          "pearson_r": -0.03503220126175015,
+          "pearson_p": 0.09807214058037354
+        },
+        "entity_organization": {
+          "pearson_r": -0.03507738864506229,
+          "pearson_p": 0.09763928001299603
+        },
+        "entity_location": {
+          "pearson_r": 0.011374095191135719,
+          "pearson_p": 0.591299261948673
+        },
+        "entity_product": {
+          "pearson_r": 0.03401006353588413,
+          "pearson_p": 0.10827888444397046
+        },
+        "entity_event": {
+          "pearson_r": -0.009036642010407625,
+          "pearson_p": 0.6696696828111034
+        },
+        "entity_law": {
+          "pearson_r": 0.03659215469187948,
+          "pearson_p": 0.08399105289067926
+        },
+        "entity_language": {
+          "pearson_r": 0.003237982907934823,
+          "pearson_p": 0.8785119669682995
+        },
+        "entity_date": {
+          "pearson_r": -0.021372004901260906,
+          "pearson_p": 0.312963461604251
+        },
+        "entity_time": {
+          "pearson_r": 0.04623490310351179,
+          "pearson_p": 0.028978528035063185
+        },
+        "entity_duration": {
+          "pearson_r": 0.01145634577571919,
+          "pearson_p": 0.5886196852295608
+        },
+        "entity_number": {
+          "pearson_r": 0.00047245138019992605,
+          "pearson_p": 0.9822062481812436
+        },
+        "entity_quantity": {
+          "pearson_r": 0.008200351774384067,
+          "pearson_p": 0.6986670418955437
+        },
+        "entity_percentage": {
+          "pearson_r": 0.05398894951998954,
+          "pearson_p": 0.010756355458036356
+        },
+        "entity_money": {
+          "pearson_r": 0.011159189304267954,
+          "pearson_p": 0.5983268174674959
+        },
+        "lcs_token": {
+          "pearson_r": 0.06791213114559927,
+          "pearson_p": 0.0013290441192195658
+        },
+        "lcs_char": {
+          "pearson_r": 0.01390556253982006,
+          "pearson_p": 0.5115207916822975
+        }
+      }
+    },
+    "model-vs-model": {
+      "n": 2231,
+      "features": {
+        "jaccard": {
+          "pearson_r": 0.1865056041605278,
+          "pearson_p": 6.542587284735683e-19
+        },
+        "dice": {
+          "pearson_r": 0.21709442424666112,
+          "pearson_p": 3.313981947516492e-25
+        },
+        "cosine": {
+          "pearson_r": 0.20468742738130716,
+          "pearson_p": 1.5715489429878018e-22
+        },
+        "rouge": {
+          "pearson_r": 0.1891267452900483,
+          "pearson_p": 2.0694141529311456e-19
+        },
+        "rouge3": {
+          "pearson_r": 0.1535865223828157,
+          "pearson_p": 3.0162081356181177e-13
+        },
+        "mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.3937145761149773,
+          "pearson_p": 1.279397162249489e-83
+        },
+        "Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.3568551346126816,
+          "pearson_p": 5.530339578603697e-68
+        },
+        "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.019491838068701476,
+          "pearson_p": 0.35744816236600463
+        },
+        "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": -0.0034008742168205224,
+          "pearson_p": 0.8724513788065029
+        },
+        "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.019492150646230597,
+          "pearson_p": 0.3574404509122045
+        },
+        "SOFT_COL_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": -0.0034010113303700835,
+          "pearson_p": 0.8724462804128771
+        },
+        "PREC_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.42036040293311966,
+          "pearson_p": 3.098457383557813e-96
+        },
+        "REC_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.40401605958742526,
+          "pearson_p": 2.3202647841715835e-88
+        },
+        "PREC_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.3814626180353335,
+          "pearson_p": 3.3928973163080636e-78
+        },
+        "REC_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.3685461215920955,
+          "pearson_p": 1.0046407874570829e-72
+        },
+        "entailment": {
+          "pearson_r": 0.5182318529693669,
+          "pearson_p": 1.3713164149670847e-153
+        },
+        "neutral": {
+          "pearson_r": -0.10707645177108602,
+          "pearson_p": 3.992037494252995e-07
+        },
+        "contradiction": {
+          "pearson_r": -0.5107633712779054,
+          "pearson_p": 1.5936501458545797e-148
+        },
+        "entity_person": {
+          "pearson_r": 0.061715262249940936,
+          "pearson_p": 0.003543552949670461
+        },
+        "entity_organization": {
+          "pearson_r": 0.012152966572605974,
+          "pearson_p": 0.5661531116698963
+        },
+        "entity_location": {
+          "pearson_r": 0.06415269761646987,
+          "pearson_p": 0.0024327833560086965
+        },
+        "entity_product": {
+          "pearson_r": 0.07163728568759933,
+          "pearson_p": 0.0007088534269014269
+        },
+        "entity_event": {
+          "pearson_r": 0.013144863127110551,
+          "pearson_p": 0.5348916318363753
+        },
+        "entity_law": {
+          "pearson_r": 0.032394482453113625,
+          "pearson_p": 0.1261040044844585
+        },
+        "entity_language": {
+          "pearson_r": 0.04343570240310148,
+          "pearson_p": 0.04022440904839564
+        },
+        "entity_date": {
+          "pearson_r": 0.010049582070315612,
+          "pearson_p": 0.6351986401980424
+        },
+        "entity_time": {
+          "pearson_r": 0.02069485500551207,
+          "pearson_p": 0.3285461444719947
+        },
+        "entity_duration": {
+          "pearson_r": 0.03827252184538856,
+          "pearson_p": 0.07070105796641613
+        },
+        "entity_number": {
+          "pearson_r": 0.037930900866494296,
+          "pearson_p": 0.07325345779752213
+        },
+        "entity_quantity": {
+          "pearson_r": 0.052540900021036424,
+          "pearson_p": 0.013064280286158686
+        },
+        "entity_percentage": {
+          "pearson_r": 0.09152923291030253,
+          "pearson_p": 1.4916968942680235e-05
+        },
+        "entity_money": {
+          "pearson_r": 0.012551502051816016,
+          "pearson_p": 0.5534877106723884
+        },
+        "lcs_token": {
+          "pearson_r": 0.20918460112660478,
+          "pearson_p": 1.7614963641165154e-23
+        },
+        "lcs_char": {
+          "pearson_r": 0.19547754665852285,
+          "pearson_p": 1.1862521086213601e-20
+        }
+      }
+    },
+    "reference-vs-generated": {
+      "n": 1831,
+      "features": {
+        "jaccard": {
+          "pearson_r": 0.12654394683361259,
+          "pearson_p": 5.5416024853460093e-08
+        },
+        "dice": {
+          "pearson_r": 0.16197899569789023,
+          "pearson_p": 3.114248541261198e-12
+        },
+        "cosine": {
+          "pearson_r": 0.158706769141685,
+          "pearson_p": 8.504280758016652e-12
+        },
+        "rouge": {
+          "pearson_r": 0.18953837540858,
+          "pearson_p": 2.8599547358706535e-16
+        },
+        "rouge3": {
+          "pearson_r": 0.1484984873765599,
+          "pearson_p": 1.709818760018296e-10
+        },
+        "mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.33367689034431625,
+          "pearson_p": 7.314609253960242e-49
+        },
+        "Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.2811843718968151,
+          "pearson_p": 1.2782443998265298e-34
+        },
+        "SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": -0.02592587689918596,
+          "pearson_p": 0.2675156669220343
+        },
+        "SOFT_COL_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": -0.024501015721371443,
+          "pearson_p": 0.29471032597769076
+        },
+        "SOFT_ROW_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": -0.025925798688160463,
+          "pearson_p": 0.2675171107169706
+        },
+        "SOFT_COL_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": -0.02450108647436708,
+          "pearson_p": 0.29470893120173547
+        },
+        "PREC_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.3477941273093548,
+          "pearson_p": 3.336589388206575e-53
+        },
+        "REC_mixedbread-ai/mxbai-embed-large-v1": {
+          "pearson_r": 0.3435437808482308,
+          "pearson_p": 7.145013857523777e-52
+        },
+        "PREC_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.2935925421767383,
+          "pearson_p": 1.000957833001949e-37
+        },
+        "REC_Qwen/Qwen3-Embedding-0.6B": {
+          "pearson_r": 0.29045090801494866,
+          "pearson_p": 6.3343691788863854e-37
+        },
+        "entailment": {
+          "pearson_r": 0.4414753844503693,
+          "pearson_p": 3.344301287701815e-88
+        },
+        "neutral": {
+          "pearson_r": -0.04424549353830481,
+          "pearson_p": 0.05837024345735462
+        },
+        "contradiction": {
+          "pearson_r": -0.49606203640171825,
+          "pearson_p": 2.4533659333405755e-114
+        },
+        "entity_person": {
+          "pearson_r": 0.01858879319404191,
+          "pearson_p": 0.4266464245918589
+        },
+        "entity_organization": {
+          "pearson_r": 0.020323889820174267,
+          "pearson_p": 0.38476022641473023
+        },
+        "entity_location": {
+          "pearson_r": 0.008281048853110243,
+          "pearson_p": 0.7232551698802027
+        },
+        "entity_product": {
+          "pearson_r": 0.017645945337182573,
+          "pearson_p": 0.4504791867307012
+        },
+        "entity_event": {
+          "pearson_r": 0.026719467407610702,
+          "pearson_p": 0.2531406571453295
+        },
+        "entity_law": {
+          "pearson_r": 0.03334720904662258,
+          "pearson_p": 0.15376575119215355
+        },
+        "entity_language": {
+          "pearson_r": 0.032896567483539585,
+          "pearson_p": 0.1594067032497046
+        },
+        "entity_date": {
+          "pearson_r": -0.031546596580366994,
+          "pearson_p": 0.17724104157940493
+        },
+        "entity_time": {
+          "pearson_r": 0.01675003559233034,
+          "pearson_p": 0.47380740946210514
+        },
+        "entity_duration": {
+          "pearson_r": 0.030750893637976104,
+          "pearson_p": 0.18842626708742427
+        },
+        "entity_number": {
+          "pearson_r": 0.01918442328016205,
+          "pearson_p": 0.41197675323817806
+        },
+        "entity_quantity": {
+          "pearson_r": -0.005895237640069066,
+          "pearson_p": 0.8009728621833548
+        },
+        "entity_percentage": {
+          "pearson_r": 0.04832023845787876,
+          "pearson_p": 0.038693874999002606
+        },
+        "entity_money": {
+          "pearson_r": 0.011214097292294833,
+          "pearson_p": 0.6315540272115223
+        },
+        "lcs_token": {
+          "pearson_r": 0.1295957471371435,
+          "pearson_p": 2.6196857082655507e-08
+        },
+        "lcs_char": {
+          "pearson_r": 0.10116557652922092,
+          "pearson_p": 1.4439574926115062e-05
+        }
+      }
+    }
+  }
+}

--- a/ablation_reports/experiments/20260401_201228_v3.0-all-modes/experiment.md
+++ b/ablation_reports/experiments/20260401_201228_v3.0-all-modes/experiment.md
@@ -1,0 +1,399 @@
+# Ablation Experiment Report
+Generated: 2026-04-01T20:12:28.439682  |  Tag: v3.0-all-modes  |  Pairs: 6293  |  Missing: 0
+
+## Run Parameters
+- Mode filter: all
+- Split filter: all
+- Framework version: 1.0
+- Bonferroni threshold: p < 1.4706e-03
+- Redundancy threshold: max_cross_r >= 0.85
+
+## Global Clustering Metrics
+- K-means ARI (k=2): 0.0617
+- PCA PC01 explained variance: 0.340  (cumulative PC05: 0.555)
+
+## Verdict Summary
+| Verdict | Count | Features |
+|---------|-------|---------|
+| KEEP | 9 | rouge3, mixedbread-ai/mxbai-embed-large-v1, PREC_mixedbread-ai/mxbai-embed-large-v1, REC_mixedbread-ai/mxbai-embed-large-v1, PREC_Qwen/Qwen3-Embedding-0.6B, entailment, neutral, contradiction, entity_percentage |
+| REVIEW | 20 | jaccard, dice, cosine, rouge, Qwen/Qwen3-Embedding-0.6B, SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1, SOFT_COL_mixedbread-ai/mxbai-embed-large-v1, SOFT_COL_Qwen/Qwen3-Embedding-0.6B, REC_Qwen/Qwen3-Embedding-0.6B, entity_person, entity_organization, entity_location, entity_product, entity_law, entity_language, entity_time, entity_duration, entity_number, lcs_token, lcs_char |
+| DROP | 5 | SOFT_ROW_Qwen/Qwen3-Embedding-0.6B, entity_event, entity_date, entity_quantity, entity_money |
+
+## Tier Summary
+| Tier | Count | Features |
+|------|-------|---------|
+| STRONG | 6 | mixedbread-ai/mxbai-embed-large-v1, PREC_mixedbread-ai/mxbai-embed-large-v1, REC_mixedbread-ai/mxbai-embed-large-v1, PREC_Qwen/Qwen3-Embedding-0.6B, entailment, contradiction |
+| MODERATE | 7 | jaccard, dice, cosine, rouge, Qwen/Qwen3-Embedding-0.6B, REC_Qwen/Qwen3-Embedding-0.6B, lcs_token |
+| WEAK | 4 | rouge3, neutral, entity_percentage, lcs_char |
+| MARGINAL | 12 | SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1, SOFT_COL_mixedbread-ai/mxbai-embed-large-v1, SOFT_COL_Qwen/Qwen3-Embedding-0.6B, entity_person, entity_organization, entity_location, entity_product, entity_law, entity_language, entity_time, entity_duration, entity_number |
+| NOISE | 5 | SOFT_ROW_Qwen/Qwen3-Embedding-0.6B, entity_event, entity_date, entity_quantity, entity_money |
+
+## Per-Feature Detail
+(sorted by |Pearson r| descending)
+
+### entailment -- STRONG -- KEEP
+- Pearson r: +0.4904  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.4878
+- Cohen's d: 1.1251
+- Mutual Info: 0.3753 bits
+- Max cross-r: 0.6380 with 'neutral' (redundant: no)
+- Mode consistency: 1.00
+- **Reason:** Strong multi-measure signal. Core feature. Pearson r=+0.4904 (p=0.00e+00, Bonferroni:OK), Spearman r=+0.4878, Cohen's d=1.1251, MI=0.3753 bits, mode_consistency=1.00
+
+### contradiction -- STRONG -- KEEP
+- Pearson r: -0.4826  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: -0.4670
+- Cohen's d: -1.1021
+- Mutual Info: 0.3814 bits
+- Max cross-r: 0.4801 with 'entailment' (redundant: no)
+- Mode consistency: 1.00
+- **Reason:** Strong multi-measure signal. Core feature. Pearson r=-0.4826 (p=0.00e+00, Bonferroni:OK), Spearman r=-0.4670, Cohen's d=-1.1021, MI=0.3814 bits, mode_consistency=1.00
+
+### PREC_mixedbread-ai/mxbai-embed-large-v1 -- STRONG -- KEEP
+- Pearson r: +0.2928  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.2993
+- Cohen's d: 0.6123
+- Mutual Info: 0.2756 bits
+- Max cross-r: 0.9661 with 'mixedbread-ai/mxbai-embed-large-v1' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Strong multi-measure signal. Core feature. Pearson r=+0.2928 (p=1.34e-124, Bonferroni:OK), Spearman r=+0.2993, Cohen's d=0.6123, MI=0.2756 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9661 with 'mixedbread-ai/mxbai-embed-large-v1' (cross_r=+0.9661)
+
+### REC_mixedbread-ai/mxbai-embed-large-v1 -- STRONG -- KEEP
+- Pearson r: +0.2813  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.2873
+- Cohen's d: 0.5863
+- Mutual Info: 0.2605 bits
+- Max cross-r: 0.9670 with 'mixedbread-ai/mxbai-embed-large-v1' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Strong multi-measure signal. Core feature. Pearson r=+0.2813 (p=8.12e-115, Bonferroni:OK), Spearman r=+0.2873, Cohen's d=0.5863, MI=0.2605 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9670 with 'mixedbread-ai/mxbai-embed-large-v1' (cross_r=+0.9670)
+
+### mixedbread-ai/mxbai-embed-large-v1 -- STRONG -- KEEP
+- Pearson r: +0.2729  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.2778
+- Cohen's d: 0.5674
+- Mutual Info: 0.2688 bits
+- Max cross-r: 0.9670 with 'REC_mixedbread-ai/mxbai-embed-large-v1' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Strong multi-measure signal. Core feature. Pearson r=+0.2729 (p=6.32e-108, Bonferroni:OK), Spearman r=+0.2778, Cohen's d=0.5674, MI=0.2688 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9670 with 'REC_mixedbread-ai/mxbai-embed-large-v1' (cross_r=+0.9670)
+
+### PREC_Qwen/Qwen3-Embedding-0.6B -- STRONG -- KEEP
+- Pearson r: +0.2537  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.2529
+- Cohen's d: 0.5244
+- Mutual Info: 0.2665 bits
+- Max cross-r: 0.9634 with 'Qwen/Qwen3-Embedding-0.6B' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Strong multi-measure signal. Core feature. Pearson r=+0.2537 (p=5.63e-93, Bonferroni:OK), Spearman r=+0.2529, Cohen's d=0.5244, MI=0.2665 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9634 with 'Qwen/Qwen3-Embedding-0.6B' (cross_r=+0.9634)
+
+### REC_Qwen/Qwen3-Embedding-0.6B -- MODERATE -- REVIEW
+- Pearson r: +0.2440  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.2407
+- Cohen's d: 0.5032
+- Mutual Info: 0.2512 bits
+- Max cross-r: 0.9664 with 'Qwen/Qwen3-Embedding-0.6B' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Moderate signal but highly correlated with 'Qwen/Qwen3-Embedding-0.6B'. Ablation test recommended before dropping. Pearson r=+0.2440 (p=5.56e-86, Bonferroni:OK), Spearman r=+0.2407, Cohen's d=0.5032, MI=0.2512 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9664 with 'Qwen/Qwen3-Embedding-0.6B' (cross_r=+0.9664)
+
+### Qwen/Qwen3-Embedding-0.6B -- MODERATE -- REVIEW
+- Pearson r: +0.2356  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.2340
+- Cohen's d: 0.4847
+- Mutual Info: 0.2595 bits
+- Max cross-r: 0.9664 with 'REC_Qwen/Qwen3-Embedding-0.6B' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Moderate signal but highly correlated with 'REC_Qwen/Qwen3-Embedding-0.6B'. Ablation test recommended before dropping. Pearson r=+0.2356 (p=4.42e-80, Bonferroni:OK), Spearman r=+0.2340, Cohen's d=0.4847, MI=0.2595 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9664 with 'REC_Qwen/Qwen3-Embedding-0.6B' (cross_r=+0.9664)
+
+### dice -- MODERATE -- REVIEW
+- Pearson r: +0.1460  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.1529
+- Cohen's d: 0.2951
+- Mutual Info: 0.1117 bits
+- Max cross-r: 0.9828 with 'jaccard' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Moderate signal but highly correlated with 'jaccard'. Ablation test recommended before dropping. Pearson r=+0.1460 (p=2.50e-31, Bonferroni:OK), Spearman r=+0.1529, Cohen's d=0.2951, MI=0.1117 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9828 with 'jaccard' (cross_r=+0.9828)
+
+### cosine -- MODERATE -- REVIEW
+- Pearson r: +0.1388  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.1409
+- Cohen's d: 0.2802
+- Mutual Info: 0.2341 bits
+- Max cross-r: 0.9380 with 'dice' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1388 (p=1.96e-28, Bonferroni:OK), Spearman r=+0.1409, Cohen's d=0.2802, MI=0.2341 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9380 with 'dice' (cross_r=+0.9380)
+
+### jaccard -- MODERATE -- REVIEW
+- Pearson r: +0.1309  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.1557
+- Cohen's d: 0.2641
+- Mutual Info: 0.1082 bits
+- Max cross-r: 0.9828 with 'dice' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1309 (p=1.83e-25, Bonferroni:OK), Spearman r=+0.1557, Cohen's d=0.2641, MI=0.1082 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9828 with 'dice' (cross_r=+0.9828)
+
+### rouge -- MODERATE -- REVIEW
+- Pearson r: +0.1304  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.1320
+- Cohen's d: 0.2630
+- Mutual Info: 0.1141 bits
+- Max cross-r: 0.9342 with 'dice' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1304 (p=2.88e-25, Bonferroni:OK), Spearman r=+0.1320, Cohen's d=0.2630, MI=0.1141 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9342 with 'dice' (cross_r=+0.9342)
+
+### lcs_token -- MODERATE -- REVIEW
+- Pearson r: +0.1281  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.1244
+- Cohen's d: 0.2584
+- Mutual Info: 0.0871 bits
+- Max cross-r: 0.9263 with 'dice' (redundant: yes)
+- Mode consistency: 1.00
+- **Reason:** Moderate signal but highly correlated with 'dice'. Ablation test recommended before dropping. Pearson r=+0.1281 (p=1.87e-24, Bonferroni:OK), Spearman r=+0.1244, Cohen's d=0.2584, MI=0.0871 bits, mode_consistency=1.00. REDUNDANT: max_cross_r=0.9263 with 'dice' (cross_r=+0.9263)
+
+### rouge3 -- WEAK -- KEEP
+- Pearson r: +0.1175  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.1477
+- Cohen's d: 0.2366
+- Mutual Info: 0.0884 bits
+- Max cross-r: 0.8361 with 'jaccard' (redundant: no)
+- Mode consistency: 1.00
+- **Reason:** Small but validated independent signal. Pearson r=+0.1175 (p=8.58e-21, Bonferroni:OK), Spearman r=+0.1477, Cohen's d=0.2366, MI=0.0884 bits, mode_consistency=1.00
+
+### neutral -- WEAK -- KEEP
+- Pearson r: -0.0959  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: -0.0814
+- Cohen's d: -0.1926
+- Mutual Info: 0.2907 bits
+- Max cross-r: 0.6380 with 'entailment' (redundant: no)
+- Mode consistency: 1.00
+- **Reason:** Small but validated independent signal. Pearson r=-0.0959 (p=2.52e-14, Bonferroni:OK), Spearman r=-0.0814, Cohen's d=-0.1926, MI=0.2907 bits, mode_consistency=1.00
+
+### lcs_char -- WEAK -- REVIEW
+- Pearson r: +0.0918  (p=< 1e-10, Bonferroni: OK)
+- Spearman r: +0.0905
+- Cohen's d: 0.1844
+- Mutual Info: 0.2504 bits
+- Max cross-r: 0.9213 with 'lcs_token' (redundant: yes)
+- Mode consistency: 0.67
+- **Reason:** Small signal but near-duplicate (max_cross_r>=0.85) of higher-tier feature 'lcs_token'. Ablation test before dropping. Pearson r=+0.0918 (p=2.90e-13, Bonferroni:OK), Spearman r=+0.0905, Cohen's d=0.1844, MI=0.2504 bits, mode_consistency=0.67. REDUNDANT: max_cross_r=0.9213 with 'lcs_token' (cross_r=+0.9213)
+
+### entity_percentage -- WEAK -- KEEP
+- Pearson r: +0.0658  (p=1.73e-07, Bonferroni: OK)
+- Spearman r: +0.0793
+- Cohen's d: 0.1319
+- Mutual Info: 0.0053 bits
+- Max cross-r: 0.0957 with 'entity_quantity' (redundant: no)
+- Mode consistency: 1.00
+- **Reason:** Small but validated independent signal. Pearson r=+0.0658 (p=1.73e-07, Bonferroni:OK), Spearman r=+0.0793, Cohen's d=0.1319, MI=0.0053 bits, mode_consistency=1.00
+
+### entity_product -- MARGINAL -- REVIEW
+- Pearson r: +0.0419  (p=8.86e-04, Bonferroni: OK)
+- Spearman r: +0.0398
+- Cohen's d: 0.0839
+- Mutual Info: 0.0039 bits
+- Max cross-r: 0.1444 with 'PREC_Qwen/Qwen3-Embedding-0.6B' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0419 (p=8.86e-04, Bonferroni:OK), Spearman r=+0.0398, Cohen's d=0.0839, MI=0.0039 bits, mode_consistency=0.00
+
+### entity_law -- MARGINAL -- REVIEW
+- Pearson r: +0.0340  (p=6.97e-03, Bonferroni: FAIL)
+- Spearman r: +0.0262
+- Cohen's d: 0.0681
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.0665 with 'lcs_token' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0340 (p=6.97e-03, Bonferroni:FAIL), Spearman r=+0.0262, Cohen's d=0.0681, MI=0.0000 bits, mode_consistency=0.00
+
+### entity_time -- MARGINAL -- REVIEW
+- Pearson r: +0.0296  (p=1.89e-02, Bonferroni: FAIL)
+- Spearman r: +0.0239
+- Cohen's d: 0.0592
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.2905 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.33
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0296 (p=1.89e-02, Bonferroni:FAIL), Spearman r=+0.0239, Cohen's d=0.0592, MI=0.0000 bits, mode_consistency=0.33
+
+### entity_location -- MARGINAL -- REVIEW
+- Pearson r: +0.0263  (p=3.71e-02, Bonferroni: FAIL)
+- Spearman r: +0.0292
+- Cohen's d: 0.0526
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.2940 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0263 (p=3.71e-02, Bonferroni:FAIL), Spearman r=+0.0292, Cohen's d=0.0526, MI=0.0000 bits, mode_consistency=0.00
+
+### entity_duration -- MARGINAL -- REVIEW
+- Pearson r: +0.0250  (p=4.75e-02, Bonferroni: FAIL)
+- Spearman r: +0.0227
+- Cohen's d: 0.0500
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.1115 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0250 (p=4.75e-02, Bonferroni:FAIL), Spearman r=+0.0227, Cohen's d=0.0500, MI=0.0000 bits, mode_consistency=0.00
+
+### entity_language -- MARGINAL -- REVIEW
+- Pearson r: +0.0212  (p=9.31e-02, Bonferroni: FAIL)
+- Spearman r: +0.0177
+- Cohen's d: 0.0424
+- Mutual Info: 0.0075 bits
+- Max cross-r: 0.1928 with 'entity_date' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0212 (p=9.31e-02, Bonferroni:FAIL), Spearman r=+0.0177, Cohen's d=0.0424, MI=0.0075 bits, mode_consistency=0.00
+
+### entity_quantity -- NOISE -- DROP
+- Pearson r: +0.0181  (p=1.51e-01, Bonferroni: FAIL)
+- Spearman r: +0.0271
+- Cohen's d: 0.0362
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.1342 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** No statistically significant or practically meaningful signal on any measure. Pearson r=+0.0181 (p=1.51e-01, Bonferroni:FAIL), Spearman r=+0.0271, Cohen's d=0.0362, MI=0.0000 bits, mode_consistency=0.00
+
+### entity_number -- MARGINAL -- REVIEW
+- Pearson r: +0.0173  (p=1.70e-01, Bonferroni: FAIL)
+- Spearman r: +0.0124
+- Cohen's d: 0.0346
+- Mutual Info: 0.0123 bits
+- Max cross-r: 0.1316 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0173 (p=1.70e-01, Bonferroni:FAIL), Spearman r=+0.0124, Cohen's d=0.0346, MI=0.0123 bits, mode_consistency=0.00
+
+### entity_date -- NOISE -- DROP
+- Pearson r: -0.0137  (p=2.78e-01, Bonferroni: FAIL)
+- Spearman r: -0.0179
+- Cohen's d: -0.0274
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.2623 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** No statistically significant or practically meaningful signal on any measure. Pearson r=-0.0137 (p=2.78e-01, Bonferroni:FAIL), Spearman r=-0.0179, Cohen's d=-0.0274, MI=0.0000 bits, mode_consistency=0.00
+
+### entity_money -- NOISE -- DROP
+- Pearson r: +0.0115  (p=3.60e-01, Bonferroni: FAIL)
+- Spearman r: +0.0152
+- Cohen's d: 0.0231
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.0947 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** No statistically significant or practically meaningful signal on any measure. Pearson r=+0.0115 (p=3.60e-01, Bonferroni:FAIL), Spearman r=+0.0152, Cohen's d=0.0231, MI=0.0000 bits, mode_consistency=0.00
+
+### SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1 -- MARGINAL -- REVIEW
+- Pearson r: -0.0090  (p=4.73e-01, Bonferroni: FAIL)
+- Spearman r: -0.0069
+- Cohen's d: -0.0181
+- Mutual Info: 0.0158 bits
+- Max cross-r: 1.0000 with 'SOFT_ROW_Qwen/Qwen3-Embedding-0.6B' (redundant: yes)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=-0.0090 (p=4.73e-01, Bonferroni:FAIL), Spearman r=-0.0069, Cohen's d=-0.0181, MI=0.0158 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_ROW_Qwen/Qwen3-Embedding-0.6B' (cross_r=+1.0000)
+
+### SOFT_ROW_Qwen/Qwen3-Embedding-0.6B -- NOISE -- DROP
+- Pearson r: -0.0090  (p=4.73e-01, Bonferroni: FAIL)
+- Spearman r: -0.0075
+- Cohen's d: -0.0181
+- Mutual Info: 0.0000 bits
+- Max cross-r: 1.0000 with 'SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1' (redundant: yes)
+- Mode consistency: 0.00
+- **Reason:** No statistically significant or practically meaningful signal on any measure. Pearson r=-0.0090 (p=4.73e-01, Bonferroni:FAIL), Spearman r=-0.0075, Cohen's d=-0.0181, MI=0.0000 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1' (cross_r=+1.0000)
+
+### entity_person -- MARGINAL -- REVIEW
+- Pearson r: +0.0086  (p=4.94e-01, Bonferroni: FAIL)
+- Spearman r: +0.0118
+- Cohen's d: 0.0172
+- Mutual Info: 0.0100 bits
+- Max cross-r: 0.3961 with 'Qwen/Qwen3-Embedding-0.6B' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0086 (p=4.94e-01, Bonferroni:FAIL), Spearman r=+0.0118, Cohen's d=0.0172, MI=0.0100 bits, mode_consistency=0.00
+
+### entity_event -- NOISE -- DROP
+- Pearson r: +0.0081  (p=5.21e-01, Bonferroni: FAIL)
+- Spearman r: +0.0029
+- Cohen's d: 0.0162
+- Mutual Info: 0.0000 bits
+- Max cross-r: 0.1782 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** No statistically significant or practically meaningful signal on any measure. Pearson r=+0.0081 (p=5.21e-01, Bonferroni:FAIL), Spearman r=+0.0029, Cohen's d=0.0162, MI=0.0000 bits, mode_consistency=0.00
+
+### entity_organization -- MARGINAL -- REVIEW
+- Pearson r: -0.0038  (p=7.63e-01, Bonferroni: FAIL)
+- Spearman r: -0.0020
+- Cohen's d: -0.0076
+- Mutual Info: 0.0031 bits
+- Max cross-r: 0.2737 with 'lcs_char' (redundant: no)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=-0.0038 (p=7.63e-01, Bonferroni:FAIL), Spearman r=-0.0020, Cohen's d=-0.0076, MI=0.0031 bits, mode_consistency=0.00
+
+### SOFT_COL_mixedbread-ai/mxbai-embed-large-v1 -- MARGINAL -- REVIEW
+- Pearson r: +0.0032  (p=8.01e-01, Bonferroni: FAIL)
+- Spearman r: +0.0052
+- Cohen's d: 0.0064
+- Mutual Info: 0.0227 bits
+- Max cross-r: 1.0000 with 'SOFT_COL_Qwen/Qwen3-Embedding-0.6B' (redundant: yes)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0032 (p=8.01e-01, Bonferroni:FAIL), Spearman r=+0.0052, Cohen's d=0.0064, MI=0.0227 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_COL_Qwen/Qwen3-Embedding-0.6B' (cross_r=+1.0000)
+
+### SOFT_COL_Qwen/Qwen3-Embedding-0.6B -- MARGINAL -- REVIEW
+- Pearson r: +0.0032  (p=8.01e-01, Bonferroni: FAIL)
+- Spearman r: +0.0051
+- Cohen's d: 0.0064
+- Mutual Info: 0.0053 bits
+- Max cross-r: 1.0000 with 'SOFT_COL_mixedbread-ai/mxbai-embed-large-v1' (redundant: yes)
+- Mode consistency: 0.00
+- **Reason:** Detectable association but does not survive Bonferroni correction. Retain only if domain knowledge justifies inclusion. Pearson r=+0.0032 (p=8.01e-01, Bonferroni:FAIL), Spearman r=+0.0051, Cohen's d=0.0064, MI=0.0053 bits, mode_consistency=0.00. REDUNDANT: max_cross_r=1.0000 with 'SOFT_COL_mixedbread-ai/mxbai-embed-large-v1' (cross_r=+1.0000)
+
+## PCA Top Loadings (PC01-PC05)
+| PC | Feature 1 | Loading | Feature 2 | Loading | Feature 3 | Loading |
+|----|-----------|---------|-----------|---------|-----------|---------|
+| PC01 | dice | +0.2787 | jaccard | +0.2714 | Qwen/Qwen3-Embedding-0.6B | +0.2691 |
+| PC02 | SOFT_ROW_Qwen/Qwen3-Embedding-0.6B | +0.4801 | SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1 | +0.4801 | SOFT_COL_Qwen/Qwen3-Embedding-0.6B | +0.3226 |
+| PC03 | SOFT_COL_mixedbread-ai/mxbai-embed-large-v1 | +0.4731 | SOFT_COL_Qwen/Qwen3-Embedding-0.6B | +0.4731 | contradiction | -0.2674 |
+| PC04 | SOFT_ROW_Qwen/Qwen3-Embedding-0.6B | +0.4383 | SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1 | +0.4383 | contradiction | -0.3327 |
+| PC05 | entity_date | +0.4330 | entity_language | +0.3746 | entity_location | +0.3134 |
+
+## Top-10 K-means Discriminative Features
+| Feature | Centroid Distance |
+|---------|-----------------|
+| dice | 1.6152 |
+| Qwen/Qwen3-Embedding-0.6B | 1.5425 |
+| rouge | 1.5402 |
+| jaccard | 1.5219 |
+| lcs_token | 1.5130 |
+| lcs_char | 1.5076 |
+| mixedbread-ai/mxbai-embed-large-v1 | 1.4950 |
+| cosine | 1.4758 |
+| REC_Qwen/Qwen3-Embedding-0.6B | 1.4724 |
+| PREC_Qwen/Qwen3-Embedding-0.6B | 1.4638 |
+
+## Per-Mode Pearson r
+| Feature | context-vs-generated | model-vs-model | reference-vs-generated |
+|---------|---------|---------|---------|
+| entailment | +0.5183 | +0.5182 | +0.4415 |
+| contradiction | -0.4424 | -0.5108 | -0.4961 |
+| PREC_mixedbread-ai/mxbai-embed-large-v1 | +0.1541 | +0.4204 | +0.3478 |
+| REC_mixedbread-ai/mxbai-embed-large-v1 | +0.1427 | +0.4040 | +0.3435 |
+| mixedbread-ai/mxbai-embed-large-v1 | +0.1421 | +0.3937 | +0.3337 |
+| PREC_Qwen/Qwen3-Embedding-0.6B | +0.1309 | +0.3815 | +0.2936 |
+| REC_Qwen/Qwen3-Embedding-0.6B | +0.1204 | +0.3685 | +0.2905 |
+| Qwen/Qwen3-Embedding-0.6B | +0.1205 | +0.3569 | +0.2812 |
+| dice | +0.0915 | +0.2171 | +0.1620 |
+| cosine | +0.0714 | +0.2047 | +0.1587 |
+| jaccard | +0.1076 | +0.1865 | +0.1265 |
+| rouge | +0.0546 | +0.1891 | +0.1895 |
+| lcs_token | +0.0679 | +0.2092 | +0.1296 |
+| rouge3 | +0.0531 | +0.1536 | +0.1485 |
+| neutral | -0.1344 | -0.1071 | -0.0442 |
+| lcs_char | +0.0139 | +0.1955 | +0.1012 |
+| entity_percentage | +0.0540 | +0.0915 | +0.0483 |
+| entity_product | +0.0340 | +0.0716 | +0.0176 |
+| entity_law | +0.0366 | +0.0324 | +0.0333 |
+| entity_time | +0.0462 | +0.0207 | +0.0168 |
+| entity_location | +0.0114 | +0.0642 | +0.0083 |
+| entity_duration | +0.0115 | +0.0383 | +0.0308 |
+| entity_language | +0.0032 | +0.0434 | +0.0329 |
+| entity_quantity | +0.0082 | +0.0525 | -0.0059 |
+| entity_number | +0.0005 | +0.0379 | +0.0192 |
+| entity_date | -0.0214 | +0.0100 | -0.0315 |
+| entity_money | +0.0112 | +0.0126 | +0.0112 |
+| SOFT_ROW_mixedbread-ai/mxbai-embed-large-v1 | -0.0196 | +0.0195 | -0.0259 |
+| SOFT_ROW_Qwen/Qwen3-Embedding-0.6B | -0.0196 | +0.0195 | -0.0259 |
+| entity_person | -0.0350 | +0.0617 | +0.0186 |
+| entity_event | -0.0090 | +0.0131 | +0.0267 |
+| entity_organization | -0.0351 | +0.0122 | +0.0203 |
+| SOFT_COL_mixedbread-ai/mxbai-embed-large-v1 | +0.0170 | -0.0034 | -0.0245 |
+| SOFT_COL_Qwen/Qwen3-Embedding-0.6B | +0.0170 | -0.0034 | -0.0245 |

--- a/ablation_reports/framework.md
+++ b/ablation_reports/framework.md
@@ -1,0 +1,205 @@
+# SilverBullet Feature Ablation Framework
+
+**Version:** 1.0  
+**Last updated:** 2026-04-01  
+**Script:** `backend/ablation_cluster.py`  
+**Experiment logs:** `ablation_reports/experiments/{timestamp}_{tag}/`
+
+---
+
+## Purpose
+
+This framework defines a reproducible, quantitative process for deciding whether each feature map in the SilverBullet pipeline is contributing genuine signal or is noise. Every run produces a timestamped experiment directory with a full JSON report and human-readable Markdown summary.
+
+The goal is not to blindly drop features — it is to understand *why* each feature is or is not discriminative, and to record that reasoning so it can be revisited when the training data or feature pipeline changes.
+
+---
+
+## The Six Measures
+
+Each feature is evaluated on six independent axes. No single measure is sufficient; the tier assignment (below) requires multiple conditions to hold simultaneously.
+
+### Measure A — Pearson r (feature vs label)
+
+Linear monotonic association between the spatial mean of the feature map and the binary label (0/1). Bonferroni correction applied at `alpha=0.05 / n_features`.
+
+- **Strength:** captures linear signal directly
+- **Weakness:** sensitive to outliers; misses non-linear structure
+- **Code:** `scipy.stats.pearsonr`
+
+### Measure B — Spearman r (feature vs label)
+
+Rank-based monotonic association. Robust to skewed distributions (entity maps are heavily zero-inflated — most pairs have no entities of a given type, producing a spike at 1.0 from the "both zero = agree" rule).
+
+- **Strength:** handles non-normal, zero-inflated distributions
+- **Weakness:** still misses non-monotonic relationships
+- **Code:** `scipy.stats.spearmanr`
+
+### Measure C — Cohen's d (label=0 vs label=1 groups)
+
+Standardised mean difference between the label=0 and label=1 distributions of each feature. Effect size in standard-deviation units, independent of sample size (unlike p-values, which grow with N).
+
+- **Formula:** `(mean_label1 - mean_label0) / pooled_std`
+- **Pooled std:** `sqrt((std0^2 + std1^2) / 2)` (Welch formula)
+- **Zero-variance guard:** if `pooled_std < 1e-12`, set `d = 0.0` and note `cohens_d_note: zero_variance`
+- **Strength:** interpretable regardless of N; reveals practical significance
+- **Code:** computed from numpy arrays
+
+### Measure D — Mutual Information (feature vs label)
+
+Non-parametric, non-linear association using a k-nearest-neighbour entropy estimator. Captures any statistical dependence, including non-monotonic relationships (e.g., a feature that peaks at both extremes).
+
+- **Units:** bits (divide raw nats by ln(2))
+- **Theoretical max:** 1 bit for a perfectly predictive binary label
+- **Practical range:** 0.0 (no information) to ~0.3 bits for strong features
+- **Code:** `sklearn.feature_selection.mutual_info_classif(discrete_features=False, n_neighbors=3)`
+
+### Measure E — Pairwise Feature Redundancy (cross-correlation)
+
+For each feature, the maximum absolute Pearson r it has with any *other* feature. Identifies features that are near-proxies of stronger features — keeping both adds no information to the model but does add noise channels.
+
+- **Redundancy threshold:** `max_cross_r >= 0.85`
+- **Output:** `max_cross_r` scalar + `top3_correlated_peers` list
+- **Code:** `np.corrcoef(X.T)` over the Nx34 feature matrix
+
+### Measure F — Mode Consistency Score
+
+For each of the 3 evaluation modes (context-vs-generated, reference-vs-generated, model-vs-model), features are ranked by `|Pearson r|` within that mode's data subset. Mode consistency = fraction of modes where the feature ranks in the top half (rank <= 17 of 34).
+
+- **Values:** 0.0 (no mode top-half), 0.33, 0.67, 1.0 (all modes top-half)
+- **Purpose:** a feature with high global correlation but only in one mode may be overfitting that mode's distribution
+- **Fallback:** if only one mode is present (e.g., `--mode` flag used), mode consistency is set to `null` and not used in tier assignment
+
+---
+
+## Tier Definitions
+
+Tiers are assigned by checking conditions from STRONG downward. A feature takes the highest tier whose full condition set is satisfied. All conditions within a tier must hold simultaneously (AND logic), except MARGINAL which uses OR.
+
+### STRONG
+
+| Measure | Threshold |
+|---------|-----------|
+| abs(Pearson r) | >= 0.25 |
+| Pearson p | < Bonferroni threshold (p < 0.05/n_features) |
+| abs(Spearman r) | >= 0.25 |
+| abs(Cohen's d) | >= 0.50 (medium effect) |
+| Mutual Info | >= 0.020 bits |
+| Mode consistency | >= 0.67 (top-half in >= 2 of 3 modes) |
+
+Expected features: `entailment`, `contradiction` (Pearson ~0.49, Cohen's d ~1.0+).
+
+### MODERATE
+
+| Measure | Threshold |
+|---------|-----------|
+| abs(Pearson r) | >= 0.10 |
+| Pearson p | < Bonferroni threshold |
+| abs(Spearman r) | >= 0.10 |
+| abs(Cohen's d) | >= 0.25 (small-to-medium) |
+| Mutual Info | >= 0.008 bits |
+| Mode consistency | >= 0.33 (top-half in >= 1 mode) |
+
+Expected features: all semantic PREC/REC/cosine maps (mxbai + Qwen3), lexical features (dice/jaccard/rouge/lcs), `neutral`.
+
+### WEAK
+
+| Measure | Threshold |
+|---------|-----------|
+| abs(Pearson r) | >= 0.05 |
+| Pearson p | < 0.05 (uncorrected — not Bonferroni) |
+| abs(Cohen's d) | >= 0.10 |
+| Mutual Info | >= 0.002 bits |
+
+Note: Bonferroni correction is NOT required here. With N~6000, the bar to reach p<0.05 for r=0.05 is already cleared; this tier captures genuine but small signal that doesn't survive the strict multiple-comparison correction.
+
+Expected features: `entity_percentage`, `entity_product`, `entity_law`, `entity_time`, `entity_location`, `entity_duration`.
+
+### MARGINAL
+
+Any ONE of:
+- abs(Pearson r) >= 0.02
+- abs(Cohen's d) >= 0.05
+- Mutual Info >= 0.001 bits
+
+Features here have a detectable numeric association that doesn't meet the statistical or practical threshold for WEAK. They are not confirmed noise but are not validated signal either.
+
+Expected features: `entity_language`, `entity_quantity`, `entity_number`.
+
+### NOISE
+
+Everything that does not meet MARGINAL conditions. With N=6293, even r=0.02 yields p~0.12, so features failing to reach even r=0.02 are statistically indistinguishable from random noise.
+
+Expected features: `entity_date`, `entity_money`, `entity_person`, `entity_event`, `entity_organization`, `SOFT_ROW_*`, `SOFT_COL_*`.
+
+---
+
+## Verdict Rules
+
+Evaluated in order. Verdicts are: **KEEP**, **REVIEW**, **DROP**.
+
+```
+IF tier == NOISE:
+    verdict = DROP
+
+ELSE IF tier == MARGINAL:
+    verdict = REVIEW
+    (retain only if domain knowledge justifies inclusion)
+
+ELSE IF tier == WEAK AND redundant:
+    verdict = REVIEW
+    (near-duplicate of a higher-tier feature; ablation test before dropping)
+
+ELSE IF tier == WEAK AND NOT redundant:
+    verdict = KEEP
+    (small but validated independent signal)
+
+ELSE IF tier == MODERATE AND redundant:
+    verdict = REVIEW
+    (moderate signal but highly correlated with a peer; ablation test)
+
+ELSE IF tier == MODERATE AND NOT redundant:
+    verdict = KEEP
+
+ELSE IF tier == STRONG:
+    verdict = KEEP
+    (regardless of redundancy — strong features are always kept)
+```
+
+The `reason` field in the report records the specific numeric values that determined the tier and verdict, naming any redundant peer by name.
+
+---
+
+## Redundancy Criterion
+
+A feature is **redundant** if its `max_cross_r >= 0.85` with any other feature in the set. This threshold means the two features share >72% of their variance (`r^2 = 0.72`). At this level of collinearity, a CNN cannot reliably distinguish the two channels and one can be removed without loss.
+
+Redundancy is a separate axis from the tier — it modifies the verdict but does not lower the tier label. Both the tier (signal quality) and redundancy (information uniqueness) are preserved independently in the report.
+
+---
+
+## Interpreting Results in Context
+
+### On p-values and sample size
+
+With N=6293, even r=0.025 yields p~0.045 (uncorrected). The Bonferroni threshold (~0.00147 for 34 features) is the appropriate significance gate. Features that survive Bonferroni have genuine associations. Features that fail it may still have real signal — but the claim cannot be made confidently from this dataset alone.
+
+### On the sampling argument
+
+Entity features may appear weak on the current dataset because most external training pairs (STS-B, MNLI, QQP, QNLI) contain few named entities. The `_type_agreement()` function returns 1.0 when both texts have zero entities of a type — so near-uniform entity maps are expected on entity-sparse data. To test the sampling hypothesis: filter to pairs where at least one entity of the relevant type appears in either text, then recheck the correlation. If it rises substantially, the feature is conditionally useful and worth retaining for domain-specific deployment.
+
+### On SOFT_ROW/SOFT_COL
+
+These features have p=0.47-0.80 on N=6293 — far too high to attribute to sampling. A genuine signal of r=0.03 would be detectable (p~0.017) at this N. The soft alignment maps are structurally capturing variance in the data, but that variance is orthogonal to the label. They are structural noise, not sampling noise.
+
+### On ARI
+
+K-means ARI of ~0.06 means the 34-feature space barely separates label classes unsupervised. This is expected — the CNN learns a non-linear decision boundary across all 34 channels jointly. ARI measures only whether simple Euclidean clustering in scaled feature-mean space aligns with labels, which is a much weaker task than what the CNN does. A low ARI does not mean the features are useless; it means linear clustering on spatial means is insufficient.
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-01 | Initial framework — 6 measures, 5 tiers, 3 verdicts; calibrated against 34-feature v3.0 pipeline on 6293 pairs |

--- a/backend/ablation_cluster.py
+++ b/backend/ablation_cluster.py
@@ -1,0 +1,635 @@
+"""
+Feature ablation via clustering — SilverBullet v3.0 pipeline.
+
+For each labelled pair, reduces each 34-feature map to its spatial mean
+-> Nx34 matrix. Then applies six measures of feature-label association
+and assigns each feature a tier (STRONG/MODERATE/WEAK/MARGINAL/NOISE)
+and a verdict (KEEP/REVIEW/DROP) per the framework in:
+    ablation_reports/framework.md
+
+Run:
+    python -m backend.ablation_cluster
+    python -m backend.ablation_cluster --mode context-vs-generated --tag post-cvg
+    python -m backend.ablation_cluster --split train --out ablation_reports/
+
+All six measures + decisions are written to a timestamped experiment
+directory under ablation_reports/experiments/{timestamp}_{tag}/.
+"""
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+from scipy import stats
+from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+from sklearn.feature_selection import mutual_info_classif
+from sklearn.metrics import adjusted_rand_score
+from sklearn.preprocessing import StandardScaler
+
+from backend.feature_cache import FeatureCache
+from backend.feature_registry import FEATURE_KEYS
+
+# ---------------------------------------------------------------------------
+# Framework constants (must match framework.md v1.0)
+# ---------------------------------------------------------------------------
+FRAMEWORK_VERSION = "1.0"
+BONFERRONI_ALPHA = 0.05
+
+# Tier thresholds
+STRONG_THRESHOLDS   = dict(abs_pearson=0.25, abs_spearman=0.25, abs_cohens_d=0.50, mi_bits=0.020, mode_consistency=0.67)
+MODERATE_THRESHOLDS = dict(abs_pearson=0.10, abs_spearman=0.10, abs_cohens_d=0.25, mi_bits=0.008, mode_consistency=0.33)
+WEAK_THRESHOLDS     = dict(abs_pearson=0.05, p_uncorrected=0.05, abs_cohens_d=0.10, mi_bits=0.002)
+MARGINAL_THRESHOLDS = dict(abs_pearson=0.02, abs_cohens_d=0.05, mi_bits=0.001)
+
+REDUNDANCY_THRESHOLD = 0.85  # max cross-r above which a feature is considered redundant
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def _load_pairs(mode: str | None, split: str | None) -> list[dict]:
+    data_root = Path("data")
+    records = []
+    modes  = [mode]  if mode  else ["context-vs-generated", "reference-vs-generated", "model-vs-model"]
+    splits = [split] if split else ["train", "validate", "test"]
+    for m in modes:
+        for s in splits:
+            p = data_root / m / f"{s}.json"
+            if not p.exists():
+                continue
+            data = json.loads(p.read_text(encoding="utf-8"))
+            for row in data.get("data", []):
+                records.append({"text1": row["text1"], "text2": row["text2"],
+                                "label": float(row["label"]), "mode": m})
+    return records
+
+
+def _feature_vector(cache_entry: dict) -> np.ndarray | None:
+    if not isinstance(cache_entry, dict):
+        return None
+    if set(cache_entry.keys()) != set(FEATURE_KEYS):
+        return None
+    vec = [float(np.array(cache_entry[k], dtype=np.float32).mean()) for k in FEATURE_KEYS]
+    return np.array(vec, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Six measures
+# ---------------------------------------------------------------------------
+
+def _compute_pearson(X: np.ndarray, y: np.ndarray, bonferroni_thresh: float) -> dict:
+    out = {}
+    for i, key in enumerate(FEATURE_KEYS):
+        r, p = stats.pearsonr(X[:, i], y)
+        out[key] = {"pearson_r": float(r), "pearson_p": float(p),
+                    "pearson_significant_bonferroni": bool(p < bonferroni_thresh)}
+    return out
+
+
+def _compute_spearman(X: np.ndarray, y: np.ndarray) -> dict:
+    out = {}
+    for i, key in enumerate(FEATURE_KEYS):
+        r, p = stats.spearmanr(X[:, i], y)
+        out[key] = {"spearman_r": float(r), "spearman_p": float(p)}
+    return out
+
+
+def _compute_cohens_d(X: np.ndarray, y_bin: np.ndarray) -> dict:
+    out = {}
+    for i, key in enumerate(FEATURE_KEYS):
+        x0 = X[y_bin == 0, i]
+        x1 = X[y_bin == 1, i]
+        pooled = np.sqrt((x0.std(ddof=1)**2 + x1.std(ddof=1)**2) / 2)
+        if pooled < 1e-12:
+            out[key] = {"cohens_d": 0.0, "cohens_d_note": "zero_variance"}
+        else:
+            out[key] = {"cohens_d": float((x1.mean() - x0.mean()) / pooled)}
+    return out
+
+
+def _compute_mutual_info(X: np.ndarray, y_bin: np.ndarray) -> dict:
+    mi_nats = mutual_info_classif(X, y_bin, discrete_features=False,
+                                  n_neighbors=3, random_state=42)
+    mi_bits = mi_nats / np.log(2)
+    return {key: {"mutual_info_bits": float(mi_bits[i])} for i, key in enumerate(FEATURE_KEYS)}
+
+
+def _compute_cross_correlations(X: np.ndarray) -> dict:
+    assert X.shape[1] == len(FEATURE_KEYS)
+    C = np.corrcoef(X.T)           # (34, 34)
+    np.fill_diagonal(C, 0.0)
+    out = {}
+    for i, key in enumerate(FEATURE_KEYS):
+        abs_row = np.abs(C[i])
+        top3_idx = np.argsort(abs_row)[::-1][:3]
+        out[key] = {
+            "max_cross_r": float(abs_row[top3_idx[0]]),
+            "top3_correlated_peers": [
+                {"feature": FEATURE_KEYS[j], "cross_r": float(C[i, j])}
+                for j in top3_idx
+            ],
+        }
+    return out
+
+
+def _compute_mode_consistency(X: np.ndarray, y: np.ndarray,
+                               modes_arr: np.ndarray) -> dict:
+    unique_modes = sorted(set(modes_arr))
+    if len(unique_modes) < 2:
+        return {key: {"mode_consistency": None, "mode_ranks": None}
+                for key in FEATURE_KEYS}
+
+    mode_ranks: dict[str, list[int | None]] = {key: {} for key in FEATURE_KEYS}
+    for m in unique_modes:
+        mask = modes_arr == m
+        Xm, ym = X[mask], y[mask]
+        if mask.sum() < 10:
+            for key in FEATURE_KEYS:
+                mode_ranks[key][m] = None
+            continue
+        abs_rs = [abs(float(stats.pearsonr(Xm[:, i], ym)[0])) for i in range(len(FEATURE_KEYS))]
+        # rank 1 = highest |r|
+        order = np.argsort(abs_rs)[::-1]
+        ranks = {FEATURE_KEYS[order[rank]]: rank + 1 for rank in range(len(FEATURE_KEYS))}
+        for key in FEATURE_KEYS:
+            mode_ranks[key][m] = ranks[key]
+
+    half = len(FEATURE_KEYS) // 2
+    out = {}
+    for key in FEATURE_KEYS:
+        ranks_for_key = [mode_ranks[key].get(m) for m in unique_modes]
+        valid = [r for r in ranks_for_key if r is not None]
+        top_half_count = sum(1 for r in valid if r <= half)
+        consistency = top_half_count / len(valid) if valid else None
+        out[key] = {"mode_consistency": consistency, "mode_ranks": mode_ranks[key]}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tier + verdict assignment
+# ---------------------------------------------------------------------------
+
+def _assign_tier(fs: dict, multi_mode: bool) -> str:
+    """Assign a tier based on the six measures. fs is the merged feature dict."""
+    abs_pr  = abs(fs.get("pearson_r", 0.0))
+    abs_sr  = abs(fs.get("spearman_r", 0.0))
+    abs_d   = abs(fs.get("cohens_d", 0.0))
+    mi      = fs.get("mutual_info_bits", 0.0)
+    mc      = fs.get("mode_consistency")
+    p       = fs.get("pearson_p", 1.0)
+    bonf_ok = fs.get("pearson_significant_bonferroni", False)
+
+    # STRONG: all five conditions (mode_consistency only checked in multi-mode run)
+    mc_ok_strong = (mc is None) or (mc >= STRONG_THRESHOLDS["mode_consistency"])
+    if (abs_pr >= STRONG_THRESHOLDS["abs_pearson"] and bonf_ok and
+            abs_sr >= STRONG_THRESHOLDS["abs_spearman"] and
+            abs_d  >= STRONG_THRESHOLDS["abs_cohens_d"] and
+            mi     >= STRONG_THRESHOLDS["mi_bits"] and
+            (not multi_mode or mc_ok_strong)):
+        return "STRONG"
+
+    # MODERATE
+    mc_ok_mod = (mc is None) or (mc >= MODERATE_THRESHOLDS["mode_consistency"])
+    if (abs_pr >= MODERATE_THRESHOLDS["abs_pearson"] and bonf_ok and
+            abs_sr >= MODERATE_THRESHOLDS["abs_spearman"] and
+            abs_d  >= MODERATE_THRESHOLDS["abs_cohens_d"] and
+            mi     >= MODERATE_THRESHOLDS["mi_bits"] and
+            (not multi_mode or mc_ok_mod)):
+        return "MODERATE"
+
+    # WEAK: p < 0.05 uncorrected (not Bonferroni), other thresholds lower
+    if (abs_pr >= WEAK_THRESHOLDS["abs_pearson"] and
+            p < WEAK_THRESHOLDS["p_uncorrected"] and
+            abs_d >= WEAK_THRESHOLDS["abs_cohens_d"] and
+            mi    >= WEAK_THRESHOLDS["mi_bits"]):
+        return "WEAK"
+
+    # MARGINAL: any one of three weak conditions
+    if (abs_pr >= MARGINAL_THRESHOLDS["abs_pearson"] or
+            abs_d >= MARGINAL_THRESHOLDS["abs_cohens_d"] or
+            mi    >= MARGINAL_THRESHOLDS["mi_bits"]):
+        return "MARGINAL"
+
+    return "NOISE"
+
+
+def _assign_verdict(tier: str, fs: dict) -> tuple[str, str]:
+    """Return (verdict, reason) string pair."""
+    redundant  = fs.get("max_cross_r", 0.0) >= REDUNDANCY_THRESHOLD
+    top_peer   = (fs.get("top3_correlated_peers") or [{}])[0].get("feature", "unknown")
+    top_peer_r = (fs.get("top3_correlated_peers") or [{}])[0].get("cross_r", 0.0)
+
+    pr  = fs.get("pearson_r", 0.0)
+    p   = fs.get("pearson_p", 1.0)
+    sr  = fs.get("spearman_r", 0.0)
+    d   = fs.get("cohens_d", 0.0)
+    mi  = fs.get("mutual_info_bits", 0.0)
+    mc  = fs.get("mode_consistency")
+    bonf = "OK" if fs.get("pearson_significant_bonferroni") else "FAIL"
+
+    base = (f"Pearson r={pr:+.4f} (p={p:.2e}, Bonferroni:{bonf}), "
+            f"Spearman r={sr:+.4f}, Cohen's d={d:.4f}, MI={mi:.4f} bits")
+    if mc is not None:
+        base += f", mode_consistency={mc:.2f}"
+    if redundant:
+        base += f". REDUNDANT: max_cross_r={fs['max_cross_r']:.4f} with '{top_peer}' (cross_r={top_peer_r:+.4f})"
+
+    if tier == "NOISE":
+        return "DROP", f"No statistically significant or practically meaningful signal on any measure. {base}"
+
+    if tier == "MARGINAL":
+        return "REVIEW", (f"Detectable association but does not survive Bonferroni correction. "
+                          f"Retain only if domain knowledge justifies inclusion. {base}")
+
+    if tier == "WEAK":
+        if redundant:
+            return "REVIEW", (f"Small signal but near-duplicate (max_cross_r>={REDUNDANCY_THRESHOLD}) "
+                              f"of higher-tier feature '{top_peer}'. Ablation test before dropping. {base}")
+        return "KEEP", f"Small but validated independent signal. {base}"
+
+    if tier == "MODERATE":
+        if redundant:
+            return "REVIEW", (f"Moderate signal but highly correlated with '{top_peer}'. "
+                              f"Ablation test recommended before dropping. {base}")
+        return "KEEP", f"Moderate validated signal with independent information. {base}"
+
+    # STRONG
+    return "KEEP", f"Strong multi-measure signal. Core feature. {base}"
+
+
+# ---------------------------------------------------------------------------
+# PCA + K-means helpers
+# ---------------------------------------------------------------------------
+
+def _run_pca(X_scaled: np.ndarray, n_components: int = 10) -> dict:
+    pca = PCA(n_components=min(n_components, X_scaled.shape[1]))
+    pca.fit(X_scaled)
+    cumvar = np.cumsum(pca.explained_variance_ratio_).tolist()
+    top3_per_pc = {}
+    for i in range(pca.n_components_):
+        loading = pca.components_[i]
+        top3_idx = np.argsort(np.abs(loading))[::-1][:3]
+        top3_per_pc[f"PC{i+1:02d}"] = [
+            {"feature": FEATURE_KEYS[j], "loading": float(loading[j])}
+            for j in top3_idx
+        ]
+    return {
+        "explained_variance": pca.explained_variance_ratio_.tolist(),
+        "cumulative_variance": cumvar,
+        "top3_loadings_per_pc": top3_per_pc,
+    }
+
+
+def _run_kmeans(X_scaled: np.ndarray, y_bin: np.ndarray) -> dict:
+    km = KMeans(n_clusters=2, random_state=42, n_init=10)
+    cluster_labels = km.fit_predict(X_scaled)
+    ari = adjusted_rand_score(y_bin, cluster_labels)
+    cluster_stats = []
+    for c in [0, 1]:
+        mask = cluster_labels == c
+        cluster_stats.append({"cluster": c, "n": int(mask.sum()),
+                               "label1_rate": float(y_bin[mask].mean())})
+    centroid_diff = np.abs(km.cluster_centers_[0] - km.cluster_centers_[1])
+    top10_idx = np.argsort(centroid_diff)[::-1][:10]
+    return {
+        "ari": float(ari),
+        "cluster_stats": cluster_stats,
+        "top10_discriminative": [
+            {"feature": FEATURE_KEYS[j], "centroid_distance": float(centroid_diff[j])}
+            for j in top10_idx
+        ],
+    }
+
+
+def _run_per_mode_correlations(X: np.ndarray, y: np.ndarray,
+                                modes_arr: np.ndarray) -> dict:
+    out = {}
+    for m in sorted(set(modes_arr)):
+        mask = modes_arr == m
+        Xm, ym = X[mask], y[mask]
+        feats = {}
+        for i, key in enumerate(FEATURE_KEYS):
+            r, p = stats.pearsonr(Xm[:, i], ym)
+            feats[key] = {"pearson_r": float(r), "pearson_p": float(p)}
+        out[m] = {"n": int(mask.sum()), "features": feats}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Report building
+# ---------------------------------------------------------------------------
+
+def _build_report(meta: dict, feature_stats_all: dict,
+                  global_stats: dict, per_mode: dict) -> dict:
+    tier_summary: dict[str, list] = {t: [] for t in ["STRONG","MODERATE","WEAK","MARGINAL","NOISE"]}
+    verdict_summary: dict[str, list] = {"KEEP": [], "REVIEW": [], "DROP": []}
+
+    for key, fs in feature_stats_all.items():
+        tier_summary[fs["tier"]].append(key)
+        verdict_summary[fs["verdict"]].append(key)
+
+    return {
+        "meta": meta,
+        "global_stats": global_stats,
+        "features": feature_stats_all,
+        "tier_summary": tier_summary,
+        "verdict_summary": verdict_summary,
+        "per_mode_correlations": per_mode,
+    }
+
+
+def _generate_markdown(report: dict) -> str:
+    meta = report["meta"]
+    gs   = report["global_stats"]
+    vs   = report["verdict_summary"]
+    ts   = report["tier_summary"]
+    feats = report["features"]
+
+    lines = [
+        "# Ablation Experiment Report",
+        f"Generated: {meta['timestamp']}  |  Tag: {meta['tag']}  |  "
+        f"Pairs: {meta['n_pairs']}  |  Missing: {meta['n_missing']}",
+        "",
+        "## Run Parameters",
+        f"- Mode filter: {meta['mode_filter'] or 'all'}",
+        f"- Split filter: {meta['split_filter'] or 'all'}",
+        f"- Framework version: {meta['framework_version']}",
+        f"- Bonferroni threshold: p < {meta['bonferroni_threshold']:.4e}",
+        f"- Redundancy threshold: max_cross_r >= {REDUNDANCY_THRESHOLD}",
+        "",
+        "## Global Clustering Metrics",
+        f"- K-means ARI (k=2): {gs['kmeans']['ari']:.4f}",
+        f"- PCA PC01 explained variance: {gs['pca']['explained_variance'][0]:.3f}  "
+        f"(cumulative PC05: {gs['pca']['cumulative_variance'][4]:.3f})",
+        "",
+        "## Verdict Summary",
+        "| Verdict | Count | Features |",
+        "|---------|-------|---------|",
+    ]
+    for v in ["KEEP", "REVIEW", "DROP"]:
+        feats_v = vs[v]
+        lines.append(f"| {v} | {len(feats_v)} | {', '.join(feats_v) or '—'} |")
+
+    lines += [
+        "",
+        "## Tier Summary",
+        "| Tier | Count | Features |",
+        "|------|-------|---------|",
+    ]
+    for t in ["STRONG", "MODERATE", "WEAK", "MARGINAL", "NOISE"]:
+        feats_t = ts[t]
+        lines.append(f"| {t} | {len(feats_t)} | {', '.join(feats_t) or '—'} |")
+
+    lines += ["", "## Per-Feature Detail", "(sorted by |Pearson r| descending)", ""]
+    sorted_keys = sorted(feats.keys(), key=lambda k: abs(feats[k].get("pearson_r", 0)), reverse=True)
+    for key in sorted_keys:
+        fs = feats[key]
+        mr = fs.get("max_cross_r", 0.0)
+        peer = (fs.get("top3_correlated_peers") or [{}])[0].get("feature", "n/a")
+        mc = fs.get("mode_consistency")
+        mc_str = f"{mc:.2f}" if mc is not None else "n/a"
+        bonf_str = "OK" if fs.get("pearson_significant_bonferroni") else "FAIL"
+        p_str = f"{fs['pearson_p']:.2e}" if fs.get("pearson_p", 1) > 1e-10 else "< 1e-10"
+        lines += [
+            f"### {key} -- {fs['tier']} -- {fs['verdict']}",
+            f"- Pearson r: {fs.get('pearson_r',0):+.4f}  (p={p_str}, Bonferroni: {bonf_str})",
+            f"- Spearman r: {fs.get('spearman_r',0):+.4f}",
+            f"- Cohen's d: {fs.get('cohens_d',0):.4f}",
+            f"- Mutual Info: {fs.get('mutual_info_bits',0):.4f} bits",
+            f"- Max cross-r: {mr:.4f} with '{peer}' (redundant: {'yes' if mr >= REDUNDANCY_THRESHOLD else 'no'})",
+            f"- Mode consistency: {mc_str}",
+            f"- **Reason:** {fs.get('reason', '')}",
+            "",
+        ]
+
+    lines += [
+        "## PCA Top Loadings (PC01-PC05)",
+        "| PC | Feature 1 | Loading | Feature 2 | Loading | Feature 3 | Loading |",
+        "|----|-----------|---------|-----------|---------|-----------|---------|",
+    ]
+    for pc_label, top3 in list(gs["pca"]["top3_loadings_per_pc"].items())[:5]:
+        row = f"| {pc_label} |"
+        for entry in top3:
+            row += f" {entry['feature']} | {entry['loading']:+.4f} |"
+        lines.append(row)
+
+    lines += [
+        "",
+        "## Top-10 K-means Discriminative Features",
+        "| Feature | Centroid Distance |",
+        "|---------|-----------------|",
+    ]
+    for entry in gs["kmeans"]["top10_discriminative"]:
+        lines.append(f"| {entry['feature']} | {entry['centroid_distance']:.4f} |")
+
+    # Per-mode table
+    lines += ["", "## Per-Mode Pearson r", "| Feature | " +
+              " | ".join(report["per_mode_correlations"].keys()) + " |",
+              "|---------|" + "---------|" * len(report["per_mode_correlations"])]
+    for key in sorted_keys:
+        row = f"| {key} |"
+        for m, mdata in report["per_mode_correlations"].items():
+            r = mdata["features"].get(key, {}).get("pearson_r", 0.0)
+            row += f" {r:+.4f} |"
+        lines.append(row)
+
+    return "\n".join(lines)
+
+
+def _save_experiment(report: dict, out_dir: str, tag: str) -> Path:
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_tag = tag.replace(" ", "_").replace("/", "-")
+    exp_dir = Path(out_dir) / "experiments" / f"{ts}_{safe_tag}"
+    exp_dir.mkdir(parents=True, exist_ok=True)
+
+    (exp_dir / "experiment.json").write_text(
+        json.dumps(report, indent=2), encoding="utf-8"
+    )
+    (exp_dir / "experiment.md").write_text(
+        _generate_markdown(report), encoding="utf-8"
+    )
+    return exp_dir
+
+
+# ---------------------------------------------------------------------------
+# Print helpers
+# ---------------------------------------------------------------------------
+
+def _print_correlation_table(feature_stats_all: dict, bonferroni_thresh: float) -> None:
+    print(f"\n-- Feature correlation with label (Bonferroni p < {bonferroni_thresh:.2e}) --")
+    print(f"{'Feature':<45} {'r':>7}  {'p-value':>10}  {'sig':>5}  {'tier':<8}  {'verdict'}")
+    print("-" * 95)
+    sorted_keys = sorted(feature_stats_all.keys(),
+                         key=lambda k: abs(feature_stats_all[k].get("pearson_r", 0)), reverse=True)
+    for key in sorted_keys:
+        fs = feature_stats_all[key]
+        r  = fs.get("pearson_r", 0.0)
+        p  = fs.get("pearson_p", 1.0)
+        bonf = "***" if fs.get("pearson_significant_bonferroni") else ("*" if p < 0.05 else "ns")
+        p_str = f"{p:.2e}" if p > 1e-10 else "<1e-10"
+        bar = "#" * int(abs(r) * 30)
+        print(f"{key:<45} {r:+.4f}  {p_str:>10}  {bonf:>5}  {fs['tier']:<8}  {fs['verdict']:<6}  {bar}")
+
+
+def _print_verdict_summary(verdict_summary: dict) -> None:
+    print("\n-- Verdict Summary --")
+    for v in ["KEEP", "REVIEW", "DROP"]:
+        items = verdict_summary[v]
+        print(f"  {v:<6} ({len(items):2d}):  {', '.join(items)}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run(mode: str | None, split: str | None, out_dir: str, tag: str) -> None:
+    cache = FeatureCache()
+    records = _load_pairs(mode, split)
+    print(f"Loaded {len(records)} labelled pairs")
+
+    vectors, labels, modes_list = [], [], []
+    missing = 0
+    for rec in records:
+        entry = cache.get_features(rec["text1"], rec["text2"])
+        if entry is None:
+            missing += 1; continue
+        vec = _feature_vector(entry)
+        if vec is None:
+            missing += 1; continue
+        vectors.append(vec)
+        labels.append(rec["label"])
+        modes_list.append(rec["mode"])
+
+    print(f"  Cache hits : {len(vectors)}")
+    print(f"  Cache miss : {missing}")
+
+    if len(vectors) < 10:
+        print("Not enough cached pairs -- run precompute_features.py first.")
+        return
+
+    X          = np.stack(vectors)
+    y          = np.array(labels)
+    y_bin      = (y >= 0.5).astype(int)
+    modes_arr  = np.array(modes_list)
+    multi_mode = len(set(modes_list)) > 1
+
+    bonferroni_thresh = BONFERRONI_ALPHA / len(FEATURE_KEYS)
+
+    scaler   = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+
+    # --- Six measures ---
+    print("\nComputing measures...")
+    pearson_stats = _compute_pearson(X, y, bonferroni_thresh)
+    spearman_stats = _compute_spearman(X, y)
+    cohens_stats   = _compute_cohens_d(X, y_bin)
+    mi_stats       = _compute_mutual_info(X, y_bin)
+    cross_stats    = _compute_cross_correlations(X)
+    mode_stats     = _compute_mode_consistency(X, y, modes_arr)
+
+    # --- Merge per-feature ---
+    feature_stats_all = {}
+    for key in FEATURE_KEYS:
+        fs = {}
+        for d in [pearson_stats[key], spearman_stats[key], cohens_stats[key],
+                  mi_stats[key], cross_stats[key], mode_stats[key]]:
+            fs.update(d)
+        fs["tier"]   = _assign_tier(fs, multi_mode)
+        verdict, reason = _assign_verdict(fs["tier"], fs)
+        fs["verdict"] = verdict
+        fs["reason"]  = reason
+        feature_stats_all[key] = fs
+
+    # --- Global analyses ---
+    pca_stats   = _run_pca(X_scaled)
+    kmeans_stats = _run_kmeans(X_scaled, y_bin)
+    per_mode     = _run_per_mode_correlations(X, y, modes_arr)
+
+    # --- Print ---
+    _print_correlation_table(feature_stats_all, bonferroni_thresh)
+
+    print("\n-- PCA explained variance --")
+    for i, (ev, cv) in enumerate(zip(pca_stats["explained_variance"],
+                                     pca_stats["cumulative_variance"])):
+        bar = "#" * int(ev * 100)
+        print(f"PC{i+1:02d}  {ev:.3f}  (cum {cv:.3f})  {bar}")
+    print("\nTop-3 feature loadings per PC:")
+    for pc_label, top3 in list(pca_stats["top3_loadings_per_pc"].items())[:5]:
+        desc = "  ".join(f"{e['feature']}({e['loading']:+.3f})" for e in top3)
+        print(f"  {pc_label}: {desc}")
+
+    print(f"\n-- K-means (k=2) ARI: {kmeans_stats['ari']:.4f} --")
+    for cs in kmeans_stats["cluster_stats"]:
+        print(f"  Cluster {cs['cluster']}: {cs['n']} pairs, label=1 rate={cs['label1_rate']:.2%}")
+
+    if multi_mode:
+        print("\n-- Per-mode top-5 correlations --")
+        for m, mdata in per_mode.items():
+            sorted_feats = sorted(mdata["features"].items(),
+                                  key=lambda x: abs(x[1]["pearson_r"]), reverse=True)[:5]
+            print(f"\n  {m}  (n={mdata['n']})")
+            for k, v in sorted_feats:
+                p_str = f"{v['pearson_p']:.2e}" if v['pearson_p'] > 1e-10 else "<1e-10"
+                print(f"    {k:<45} {v['pearson_r']:+.4f}  {p_str}")
+
+    _print_verdict_summary(
+        {"KEEP":   [k for k,v in feature_stats_all.items() if v["verdict"]=="KEEP"],
+         "REVIEW": [k for k,v in feature_stats_all.items() if v["verdict"]=="REVIEW"],
+         "DROP":   [k for k,v in feature_stats_all.items() if v["verdict"]=="DROP"]}
+    )
+
+    # --- Build + save ---
+    meta = {
+        "timestamp": datetime.now().isoformat(),
+        "tag": tag,
+        "mode_filter": mode,
+        "split_filter": split,
+        "n_pairs": len(vectors),
+        "n_missing": missing,
+        "n_features": len(FEATURE_KEYS),
+        "feature_keys": FEATURE_KEYS,
+        "framework_version": FRAMEWORK_VERSION,
+        "bonferroni_alpha": BONFERRONI_ALPHA,
+        "bonferroni_threshold": bonferroni_thresh,
+        "redundancy_threshold": REDUNDANCY_THRESHOLD,
+    }
+    global_stats = {"pca": pca_stats, "kmeans": kmeans_stats}
+    report = _build_report(meta, feature_stats_all, global_stats, per_mode)
+    exp_dir = _save_experiment(report, out_dir, tag)
+
+    # Legacy flat report for backward compat
+    legacy = {
+        "n_pairs": len(vectors),
+        "n_missing": missing,
+        "feature_correlations": {k: {"r": v["pearson_r"], "p": v["pearson_p"]}
+                                  for k, v in feature_stats_all.items()},
+        "pca_explained_variance": pca_stats["explained_variance"],
+        "kmeans_ari": kmeans_stats["ari"],
+        "kmeans_top_discriminative": {e["feature"]: e["centroid_distance"]
+                                      for e in kmeans_stats["top10_discriminative"]},
+    }
+    Path(out_dir, "ablation_cluster_report.json").write_text(
+        json.dumps(legacy, indent=2), encoding="utf-8"
+    )
+
+    print(f"\nExperiment saved -> {exp_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", default=None,
+                        choices=["context-vs-generated",
+                                 "reference-vs-generated",
+                                 "model-vs-model"])
+    parser.add_argument("--split", default=None,
+                        choices=["train", "validate", "test"])
+    parser.add_argument("--out", default="ablation_reports")
+    parser.add_argument("--tag", default="run",
+                        help="Short label for the experiment directory")
+    args = parser.parse_args()
+    run(args.mode, args.split, args.out, args.tag)


### PR DESCRIPTION
## Summary

- **New script** `backend/ablation_cluster.py` — full ablation pipeline using 6 independent measures per feature map
- **New framework doc** `ablation_reports/framework.md` — permanent definition of tier thresholds, verdict rules, and interpretation guidance
- **First experiment log** `ablation_reports/experiments/20260401_201228_v3.0-all-modes/` — JSON + Markdown report on all 6293 cached pairs

## Six Measures

| Measure | What it captures |
|---------|----------------|
| Pearson r + Bonferroni p | Linear association, multiple-comparison corrected |
| Spearman r | Monotonic association robust to zero-inflated entity maps |
| Cohen's d | Practical effect size (label=0 vs label=1 group means) |
| Mutual Information (bits) | Non-linear, non-monotonic associations |
| Max cross-r (redundancy) | Whether a feature is a near-proxy of a stronger one (threshold: r >= 0.85) |
| Mode consistency | Whether signal holds across all 3 eval modes or is mode-specific |

## Tier → Verdict System

```
STRONG   → KEEP   (all 6 measures clear high thresholds)
MODERATE → KEEP / REVIEW  (mode-dependent or redundant → REVIEW)
WEAK     → KEEP / REVIEW  (redundant → REVIEW)
MARGINAL → REVIEW
NOISE    → DROP
```

## First Experiment Results (v3.0-all-modes, n=6293)

| Verdict | Count | Notable features |
|---------|-------|----------------|
| KEEP | 9 | `entailment`, `contradiction`, mxbai PREC/REC/cosine, Qwen PREC, `rouge3`, `neutral`, `entity_percentage` |
| REVIEW | 20 | Redundant or mode-dependent (lexical group, Qwen REC/cosine, most entity types, SOFT_ROW_mxbai) |
| DROP | 5 | `SOFT_ROW_Qwen`, `entity_event`, `entity_date`, `entity_quantity`, `entity_money` |

Key finding: SOFT_ROW/SOFT_COL have p=0.47–0.80 on n=6293 — confirmed structural noise, not a sampling artifact. Entity maps are likely sampling-limited (most training pairs lack named entities); `entity_percentage` is the exception with validated signal.

## Test plan

- [ ] `python -m backend.ablation_cluster --tag test` runs without error and creates a new experiment directory
- [ ] `ablation_reports/experiments/` contains timestamped subdirectory with `experiment.json` and `experiment.md`
- [ ] `experiment.json` has `tier_summary`, `verdict_summary`, and `features` keys with all 34 entries
- [ ] `ablation_reports/framework.md` documents all tier thresholds matching the code constants in `ablation_cluster.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)