### PR TITLE
fix(shap_analysis): undefined name 'data' (F821)

### DIFF
--- a/backend/shap_analysis.py
+++ b/backend/shap_analysis.py
@@ -121,7 +121,7 @@ def _load_tensors(
         y_list.append(label)
 
     if skipped:
-        print(f"  [warn] {skipped}/{len(data)} samples skipped (cache miss or key mismatch)")
+        print(f"  [warn] {skipped}/{len(pairs)} samples skipped (cache miss or key mismatch)")
 
     X = torch.stack(X_list).to(device)                             # [N, F, S, S]
     L = torch.tensor(L_list, dtype=torch.float32).to(device)      # [N, 2]


### PR DESCRIPTION
Fixes flake8 F821: `data` → `pairs` on line 124 of `backend/shap_analysis.py`. The variable holding loaded samples in `_load_tensors` is `pairs`, not `data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)