### PR TITLE
fix(tests): add min_alignment fields to breakdown fixture

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,6 +183,8 @@ def test_predict_pair_breakdown_happy_path(client, mock_predictor):
         "divergent_in_2": [],
         "feature_scores": {"Semantic (mxbai)": 0.8},
         "misalignment_reasons": [],
+        "min_alignment": 0.0,
+        "min_alignment_pair": [],
     }
     mock_predictor.predict_pair_breakdown.return_value = expected
 


### PR DESCRIPTION
The `feat(v6-A)` commit added `min_alignment` and `min_alignment_pair` to the breakdown response, but the pytest fixture in `test_predict_pair_breakdown_happy_path` was never updated. This caused 1 failed test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)